### PR TITLE
Bugfix for the JUnit test and OpenCL kernels

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/NumericGridOperator.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/NumericGridOperator.java
@@ -40,33 +40,33 @@ public class NumericGridOperator {
 	}
 
 	/** Get sum of all grid elements */
-	public double sum(final NumericGrid grid) {
-		double sum = 0;
+	public float sum(final NumericGrid grid) {
+		float sum = 0.0f;
 		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
 		while (it.hasNext())
 			sum += it.getNext();
-		return (float) sum;
+		return sum;
 	}
 	
 	/** Get sum of all grid elements */
-	public double sumSave(final NumericGrid grid) {
-		double sum = 0;
+	public float sumSave(final NumericGrid grid) {
+		float sum = 0.0f;
 		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
 		while (it.hasNext()) {
 			double val = it.getNext();
 			if (!(Double.isInfinite(val) || Double.isNaN(val)))
 				sum += val;
 		}
-		return (float) sum;
+		return sum;
 	}
 
 	/** Get l1 norm of all grid elements */
-	public double normL1(final NumericGrid grid) {
-		double res = 0;
+	public float normL1(final NumericGrid grid) {
+		float res = 0.0f;
 		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
 		while (it.hasNext()) {
-			double val = it.getNext();
-			if (!(Double.isInfinite(val) || Double.isNaN(val))) {
+			float val = it.getNext();
+			if (!(Float.isInfinite(val) || Float.isNaN(val))) {
 				if (0 > val) // add abs
 					res -= val;
 				else
@@ -92,7 +92,6 @@ public class NumericGridOperator {
 
 	public int countInvalidElements(NumericGrid grid) {
 		int res = 0;
-		
 		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
 		while (it.hasNext()) {
 			float val = it.getNext();
@@ -104,13 +103,13 @@ public class NumericGridOperator {
 
 	/** Get min of a NumericGrid */
 	public float min(final NumericGrid grid) {
-		float min = Float.MAX_VALUE;
-		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid);
-		while (it1.hasNext()) {
-			if (it1.get() < min) {
-				min = it1.get();
+		float min = +Float.MAX_VALUE;
+		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
+		while (it.hasNext()) {
+			if (it.get() < min) {
+				min = it.get();
 			}
-			it1.getNext();
+			it.getNext();
 		}
 		return min;
 	}
@@ -118,11 +117,11 @@ public class NumericGridOperator {
 	/** Get max of a NumericGrid */
 	public float max(final NumericGrid grid) {
 		float max = -Float.MAX_VALUE;
-		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid);
-		while (it1.hasNext()) {
-			if (it1.get() > max)
-				max = it1.get();
-			it1.getNext();
+		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(grid);
+		while (it.hasNext()) {
+			if (it.get() > max)
+				max = it.get();
+			it.getNext();
 		}
 		return max;
 	}
@@ -136,8 +135,8 @@ public class NumericGridOperator {
 	}
 
 	/** Compute dot product between grid1 and grid2 */
-	public double dotProduct(NumericGrid grid1, NumericGrid grid2) {
-		double value = 0.0;
+	public float dotProduct(NumericGrid grid1, NumericGrid grid2) {
+		float value = 0.0f;
 		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid1);
 		NumericPointwiseIteratorND it2 = new NumericPointwiseIteratorND(grid2);
 		while (it1.hasNext())
@@ -146,8 +145,8 @@ public class NumericGridOperator {
 	}
 	
 	/** Compute weighted dot product between grid1 and grid2 */
-	public double weightedDotProduct(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
-		double value = 0.0;
+	public float weightedDotProduct(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
+		float value = 0.0f;
 		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid1);
 		NumericPointwiseIteratorND it2 = new NumericPointwiseIteratorND(grid2);
 		while (it1.hasNext())
@@ -156,8 +155,8 @@ public class NumericGridOperator {
 	}
 	
 	/** Compute dot product between grid1 and grid2 */
-	public double weightedSSD(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
-		double value = 0.0;
+	public float weightedSSD(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
+		float value = 0.0f;
 		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid1);
 		NumericPointwiseIteratorND it2 = new NumericPointwiseIteratorND(grid2);
 		while (it1.hasNext()){
@@ -168,8 +167,8 @@ public class NumericGridOperator {
 	}
 	
 	/** Compute rmse between grid1 and grid2 */
-	public double rmse(NumericGrid grid1, NumericGrid grid2) {
-		double sum = 0.0;
+	public float rmse(NumericGrid grid1, NumericGrid grid2) {
+		float sum = 0.0f;
 		long numErrors = 0;
 		NumericPointwiseIteratorND it1 = new NumericPointwiseIteratorND(grid1);
 		NumericPointwiseIteratorND it2 = new NumericPointwiseIteratorND(grid2);
@@ -184,7 +183,7 @@ public class NumericGridOperator {
 			System.err.println("Errors in RMSE computation: "
 					+ ((double) numErrors * 100)
 					/ (grid1.getNumberOfElements()) + "%");
-		return Math.sqrt(sum/grid1.getNumberOfElements());
+		return (float)Math.sqrt(sum/grid1.getNumberOfElements());
 	}
 	
 	/** Compute grid1 = grid1 + grid2 */
@@ -331,14 +330,14 @@ public class NumericGridOperator {
 			it.setNext((it.get() < 0) ? 0 : it.get());
 	}
 
-	public double stddev(NumericGrid data, double mean) {
-		double theStdDev = 0;
+	public float stddev(NumericGrid data, double mean) {
+		float theStdDev = 0.0f;
 		NumericPointwiseIteratorND it = new NumericPointwiseIteratorND(data);
 		while (it.hasNext()){
 			double value =(it.getNext() - mean);
 			theStdDev += value*value;
 		}
-		return Math.sqrt(theStdDev / data.getNumberOfElements());
+		return (float)Math.sqrt(theStdDev / data.getNumberOfElements());
 	}
 
 	public void abs(NumericGrid data) {

--- a/src/edu/stanford/rsl/conrad/data/numeric/NumericPointwiseOperators.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/NumericPointwiseOperators.java
@@ -29,7 +29,7 @@ public abstract class NumericPointwiseOperators {
 	}
 
 	/** Get sum of all grid elements */
-	public static double sum(final NumericGrid grid) {
+	public static float sum(final NumericGrid grid) {
 		return grid.getGridOperator().sum(grid);
 	}
 	
@@ -50,25 +50,25 @@ public abstract class NumericPointwiseOperators {
 	}
 
 	/** Compute dot product between grid1 and grid2 */
-	public static double dotProduct(NumericGrid grid1, NumericGrid grid2) {
+	public static float dotProduct(NumericGrid grid1, NumericGrid grid2) {
 		NumericGridOperator op = selectGridOperator(grid1, grid2);
 		return op.dotProduct(grid1, grid2);
 	}
 	
 	/** Compute dot product between grid1 and grid2 */
-	public static double weightedSSD(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
+	public static float weightedSSD(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double addGrid2) {
 		NumericGridOperator op = selectGridOperator(grid1, grid2);
 		return op.weightedSSD(grid1, grid2, weightGrid2, addGrid2);
 	}
 	
 	/** Compute dot product between grid1 and grid2 */
-	public static double weightedDotProduct(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double subGrid2) {
+	public static float weightedDotProduct(NumericGrid grid1, NumericGrid grid2, double weightGrid2, double subGrid2) {
 		NumericGridOperator op = selectGridOperator(grid1, grid2);
 		return op.weightedSSD(grid1, grid2, weightGrid2, subGrid2);
 	}
 
 	/** Compute dot product between grid and itself. Same as square of l2 norm */
-	public static double dotProduct(NumericGrid grid) {
+	public static float dotProduct(NumericGrid grid) {
 		return dotProduct(grid, grid);
 	}
 
@@ -152,11 +152,11 @@ public abstract class NumericPointwiseOperators {
 		grid.getGridOperator().removeNegative(grid);
 	}
 	
-	public static double mean(NumericGrid data) {
+	public static float mean(NumericGrid data) {
 		return sum(data)/data.getNumberOfElements();
 	}
 
-	public static double stddev(NumericGrid data, double mean) {
+	public static float stddev(NumericGrid data, double mean) {
 		return data.getGridOperator().stddev(data, mean);
 	}
 

--- a/src/edu/stanford/rsl/conrad/data/numeric/NumericPointwiseOperators.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/NumericPointwiseOperators.java
@@ -9,12 +9,12 @@ import edu.stanford.rsl.conrad.data.numeric.opencl.OpenCLGridOperators;
 
 
 /** The collection of all operators working point-wise on NumericGrid data. */
-public abstract class NumericPointwiseOperators{
+public abstract class NumericPointwiseOperators {
 	/*
 	 * Auxiliary method to select a combined grid operator
 	 */
 	public static NumericGridOperator selectGridOperator(NumericGrid ... grids) {
-		boolean nonCLFound =false;
+		boolean nonCLFound = false;
 		for (NumericGrid grid : grids){
 			if (!(grid instanceof OpenCLGridInterface)){
 				nonCLFound = true;

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLBenchmark.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLBenchmark.java
@@ -109,14 +109,24 @@ public class OpenCLBenchmark {
 		System.out.format("+----------------------+-------+--------+%n");
 		
 		
-		// last, but not lead: min
+		// last, but not lead: 
+		// dot product
 		Grid2D grid2D = new Grid2D(512, 512);
-		
-		grid2D.setAtIndex(1, 2, -0.12345f);
+		for(int i = 0; i<512; i++) {
+			for(int j = 0; j<512; j++) {
+				float val = 1.0f;
+				grid2D.setAtIndex(i, j, val);
+			}
+		}
 		
 		OpenCLGrid2D openCLGrid2D = new OpenCLGrid2D(grid2D, context, device);
+		double dotProduct = openCLGrid2D.getGridOperator().dotProduct(openCLGrid2D, openCLGrid2D);
+		System.out.println("dot product: " + dotProduct);
+
+		//min
+		openCLGrid2D.setAtIndex(1, 2, -0.12345f);
 		float min = openCLGrid2D.getGridOperator().min(openCLGrid2D);
-		System.out.println("min:" + min);
+		System.out.println("min: " + min);
 		
 
 		

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLBenchmark.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLBenchmark.java
@@ -115,8 +115,6 @@ public class OpenCLBenchmark {
 		grid2D.setAtIndex(1, 2, -0.12345f);
 		
 		OpenCLGrid2D openCLGrid2D = new OpenCLGrid2D(grid2D, context, device);
-		openCLGrid2D.getGridOperator().sum(openCLGrid2D); // initialize
-		
 		float min = openCLGrid2D.getGridOperator().min(openCLGrid2D);
 		System.out.println("min:" + min);
 		

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid1D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid1D.java
@@ -21,9 +21,10 @@ public class OpenCLGrid1D extends Grid1D implements OpenCLGridInterface{
 	// ************************ Constructors and copying  *************************************
 	// ****************************************************************************************
 	
-	public OpenCLGrid1D(Grid1D input, CLContext context, CLDevice device){
+	public OpenCLGrid1D(Grid1D input, CLContext context, CLDevice device) {
 		super(input);
 		this.initializeDelegate(context, device);
+		this.numericGridOperator = OpenCLGridOperators.getInstance();
 	}
 
 	public OpenCLGrid1D(Grid1D input) {
@@ -31,7 +32,7 @@ public class OpenCLGrid1D extends Grid1D implements OpenCLGridInterface{
 	}
 	
 	@Override
-	public OpenCLGrid1D clone(){
+	public OpenCLGrid1D clone() {
 		notifyBeforeRead();
 		return new OpenCLGrid1D(this, delegate.getCLContext(), delegate.getCLDevice());
 	}

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid2D.java
@@ -21,7 +21,7 @@ public class OpenCLGrid2D extends Grid2D implements OpenCLGridInterface {
 	// ************************ Constructors and copying  *************************************
 	// ****************************************************************************************
 	
-	public OpenCLGrid2D(Grid2D input, CLContext context, CLDevice device){
+	public OpenCLGrid2D(Grid2D input, CLContext context, CLDevice device) {
 		super(input);
 		this.initializeDelegate(context, device);
 		this.numericGridOperator = OpenCLGridOperators.getInstance();
@@ -34,7 +34,7 @@ public class OpenCLGrid2D extends Grid2D implements OpenCLGridInterface {
 	
 	
 	@Override
-	public OpenCLGrid2D clone(){
+	public OpenCLGrid2D clone() {
 		notifyBeforeRead();
 		return new OpenCLGrid2D(this, delegate.getCLContext(), delegate.getCLDevice());
 	}

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid3D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGrid3D.java
@@ -21,9 +21,10 @@ public class OpenCLGrid3D extends Grid3D implements OpenCLGridInterface {
 	// ************************ Constructors and copying  *************************************
 	// ****************************************************************************************
 	
-	public OpenCLGrid3D(Grid3D input, CLContext context, CLDevice device){
+	public OpenCLGrid3D(Grid3D input, CLContext context, CLDevice device) {
 		super(input);
 		this.initializeDelegate(context, device);
+		this.numericGridOperator = OpenCLGridOperators.getInstance();
 	}
 
 	public OpenCLGrid3D(Grid3D input) {
@@ -31,7 +32,7 @@ public class OpenCLGrid3D extends Grid3D implements OpenCLGridInterface {
 	}
 	
 	@Override
-	public OpenCLGrid3D clone(){
+	public OpenCLGrid3D clone() {
 		notifyBeforeRead();
 		return new OpenCLGrid3D(this, delegate.getCLContext(), delegate.getCLDevice());
 	}

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridOperators.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridOperators.java
@@ -600,7 +600,8 @@ public class OpenCLGridOperators extends NumericGridOperator {
 		clGrid.getDelegate().notifyDeviceChange();
 	}
 
-
+	/*
+	 * not yet implemented
 	@Override
 	public void removeNegative(final NumericGrid grid) {		
 		// not possible to have a grid that is not implementing OpenCLGridInterface
@@ -613,7 +614,7 @@ public class OpenCLGridOperators extends NumericGridOperator {
 		runKernel("minimalValue", device, clmem, 0);
 		clGrid.getDelegate().notifyDeviceChange();
 	}
-
+	*/
 
 	@Override
 	public void pow(final NumericGrid grid, double val) {		

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridTest.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridTest.java
@@ -72,6 +72,7 @@ public class OpenCLGridTest {
 			grid1D2 = new Grid1D(buffer2);
 			clgrid1D = new OpenCLGrid1D(grid1D);
 			clgrid1D2 = new OpenCLGrid1D(grid1D2);
+
 			
 			//Check if its a auxiliary method? Yes, ignore it!
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
@@ -154,11 +155,13 @@ public class OpenCLGridTest {
 							
 //					Ergebnis ist ein float
 					} else if (ergStr1D.equals(parClassFloat) && clergStr1D.equals(parClassFloat)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg1D) - (Float) (clerg1D),2), Math.pow((Float) (erg1D) - (Float) (clerg1D),2) < smallValue);
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg1D) - (Float) (clerg1D),2), Math.pow((Float) (erg1D) - (Float) (clerg1D),2) < smallValue);
 						
 //					Ergebnis ist ein double
 					} else if (ergStr1D.equals(parClassDouble) && clergStr1D.equals(parClassDouble)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg1D) - (Double) (clerg1D),2), Math.pow((Double) (erg1D) - (Double) (clerg1D),2) < smallValue);
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg1D) - (Double) (clerg1D),2), Math.pow((Double) (erg1D) - (Double) (clerg1D),2) < smallValue);
 
 					} else {
 						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);
@@ -219,6 +222,7 @@ public class OpenCLGridTest {
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
 				continue;
 			
+						
 			System.out.println(methods[i]);
 			
 			Class<?>[] param = methods[i].getParameterTypes();
@@ -257,7 +261,6 @@ public class OpenCLGridTest {
 					clparamSet2D[j] = 2.0;
 
 				}
-
 			}
 
 			try {
@@ -306,11 +309,12 @@ public class OpenCLGridTest {
 							
 //					Ergebnis ist ein float
 					} else if (ergStr2D.equals(parClassFloat) && clergStr2D.equals(parClassFloat)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg2D) - (Float) (clerg2D),2), Math.pow((Float) (erg2D) - (Float) (clerg2D),2) < smallValue);
-						
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg2D) - (Float) (clerg2D),2), Math.pow((Float) (erg2D) - (Float) (clerg2D),2) < smallValue);
 //					Ergebnis ist ein double
 					} else if (ergStr2D.equals(parClassDouble) && clergStr2D.equals(parClassDouble)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg2D) - (Double) (clerg2D),2), Math.pow((Double) (erg2D) - (Double) (clerg2D),2) < smallValue);
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg2D) - (Double) (clerg2D),2), Math.pow((Double) (erg2D) - (Double) (clerg2D),2) < smallValue);
 
 					} else {
 						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);
@@ -329,7 +333,6 @@ public class OpenCLGridTest {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
-
 		}
 	}
 	
@@ -383,7 +386,7 @@ public class OpenCLGridTest {
 			//Check if its a auxiliary method? Yes, ignore it!
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
 				continue;
-			
+
 			System.out.println(methods[i]);
 			
 			Class<?>[] param = methods[i].getParameterTypes();
@@ -461,11 +464,13 @@ public class OpenCLGridTest {
 							
 //					Ergebnis ist ein float
 					} else if (ergStr3D.equals(parClassFloat) && clergStr3D.equals(parClassFloat)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg3D) - (Float) (clerg3D),2), Math.pow((Float) (erg3D) - (Float) (clerg3D),2) < smallValue);
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg3D) - (Float) (clerg3D),2), Math.pow((Float) (erg3D) - (Float) (clerg3D),2) < smallValue);
 						
 //					Ergebnis ist ein double
 					} else if (ergStr3D.equals(parClassDouble) && clergStr3D.equals(parClassDouble)) {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg3D) - (Double) (clerg3D),2), Math.pow((Double) (erg3D) - (Double) (clerg3D),2) < smallValue);
+						// TODO: Check here: this test is not working, but the results are correct
+						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg3D) - (Double) (clerg3D),2), Math.pow((Double) (erg3D) - (Double) (clerg3D),2) < smallValue);
 
 					} else {
 						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridTest.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/OpenCLGridTest.java
@@ -31,15 +31,11 @@ public class OpenCLGridTest {
 	
 	void fillBufferOnes(float[] buffer) {
 		for (int i = 0; i < buffer.length; i++) {
-			buffer[i]=1.0f;
+			buffer[i] = 1.0f;
 		}
 	}
 
-	@Test
-	public void startup() {
-		OpenCLUtil.getStaticContext();
-	}
-	
+
 	@Test
 	public void allMethods1DTest() {
 		
@@ -78,7 +74,7 @@ public class OpenCLGridTest {
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
 				continue;
 			
-			System.out.println(methods[i]);
+			System.out.println(formatMethodName(methods[i]));
 			
 			Class<?>[] param = methods[i].getParameterTypes();
 
@@ -127,7 +123,7 @@ public class OpenCLGridTest {
 				// wenn erg = null dann ist methode void
 				if(erg1D == null && clerg1D == null) {
 					double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((NumericGrid)(paramSet1D[0]), (NumericGrid) (clparamSet1D[0]))));
-					Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+					Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 				} else if (erg1D != null && clerg1D != null) {
 					
 					String ergStr1D = erg1D.getClass().getName();
@@ -136,39 +132,38 @@ public class OpenCLGridTest {
 //					Ergebnis ist ein Grid
 					if (ergStr1D.equals(parClassGrid) && clergStr1D.equals(parClassGrid)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((NumericGrid)(erg1D), (NumericGrid) (clerg1D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 
 //					Ergebnis ist ein 1DGrid		
 					} else if (ergStr1D.equals(parClassGrid1D) && clergStr1D.equals(parClassCLGrid1D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid1D)(erg1D), (Grid1D) (clerg1D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
 //					Ergebnis ist ein 2DGrid		
 					} else if (ergStr1D.equals(parClassGrid2D) && clergStr1D.equals(parClassCLGrid2D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid2D)(erg1D), (Grid2D) (clerg1D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 						
 //					Ergebnis ist ein 3DGrid		
 					} else if (ergStr1D.equals(parClassGrid3D) && clergStr1D.equals(parClassCLGrid3D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid3D)(erg1D), (Grid3D) (clerg1D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
 //					Ergebnis ist ein float
 					} else if (ergStr1D.equals(parClassFloat) && clergStr1D.equals(parClassFloat)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg1D) - (Float) (clerg1D),2), Math.pow((Float) (erg1D) - (Float) (clerg1D),2) < smallValue);
-						
+						double diff = Math.pow((float)erg1D - (float)clerg1D, 2);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);						
 //					Ergebnis ist ein double
 					} else if (ergStr1D.equals(parClassDouble) && clergStr1D.equals(parClassDouble)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg1D) - (Double) (clerg1D),2), Math.pow((Double) (erg1D) - (Double) (clerg1D),2) < smallValue);
+						double diff = Math.pow((Double)erg1D - (Double)clerg1D, 2);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);
 
 					} else {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED.  Result types do not agree or are not defined.", false);
 					}
 					
 				} else {
-					Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Result types do not agree.", false);
+					Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Result types do not agree.", false);
 				}
 			} catch(IllegalAccessException e){
 				e.printStackTrace();
@@ -192,12 +187,10 @@ public class OpenCLGridTest {
 		OpenCLGrid2D clgrid2D;
 		OpenCLGrid2D clgrid2D2;
 		
-		
 		float[] buffer1 = new float[300];
 		float[] buffer2 = new float[300];
 		fillBufferRandom(buffer1);
 		fillBufferRandom(buffer2);
-
 
 		String parClassGrid = "edu.stanford.rsl.conrad.data.numeric.NumericGrid";
 		String parClassGrid2D = "edu.stanford.rsl.conrad.data.numeric.Grid2D";
@@ -222,8 +215,7 @@ public class OpenCLGridTest {
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
 				continue;
 			
-						
-			System.out.println(methods[i]);
+			System.out.println(formatMethodName(methods[i]));
 			
 			Class<?>[] param = methods[i].getParameterTypes();
 
@@ -236,30 +228,23 @@ public class OpenCLGridTest {
 			for (int j = 0; j < paramLength; j++) {
 
 				String argstr = param[j].getName();
-				// Class<?> paramClass = Class.forName(argstr);
 
 				if (argstr.equals(parClassGrid)) {
 					if (c == 0) {
 						paramSet2D[j] = grid2D.clone();
 						clparamSet2D[j] = clgrid2D.clone();
-
 						c++;
 					}
 					else {
 						paramSet2D[j] = grid2D2.clone();
 						clparamSet2D[j] = clgrid2D2.clone();
-						
 					}
-
 				} else if (argstr.equals("float")) {
 					paramSet2D[j] = 2.f;
-					clparamSet2D[j] = 2.f;
-
-					
+					clparamSet2D[j] = 2.f;					
 				} else if (argstr.equals("double")) {
 					paramSet2D[j] = 2.0;
 					clparamSet2D[j] = 2.0;
-
 				}
 			}
 
@@ -278,9 +263,9 @@ public class OpenCLGridTest {
 					   || (methods[i].toString().equals("public static void edu.stanford.rsl.conrad.data.NumericalPointwiseOperators.sqrt(edu.stanford.rsl.conrad.data.numeric.NumericGrid)"))
 						)
 					{
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 					} else {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 					}
 				} else if (erg2D != null && clerg2D != null) {
 					
@@ -290,38 +275,36 @@ public class OpenCLGridTest {
 //					Ergebnis ist ein Grid
 					if (ergStr2D.equals(parClassGrid) && clergStr2D.equals(parClassGrid)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((NumericGrid)(erg2D), (NumericGrid) (clerg2D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 
 //					Ergebnis ist ein 1DGrid		
 					} else if (ergStr2D.equals(parClassGrid1D) && clergStr2D.equals(parClassCLGrid1D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid1D)(erg2D), (Grid1D) (clerg2D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
 //					Ergebnis ist ein 2DGrid		
 					} else if (ergStr2D.equals(parClassGrid2D) && clergStr2D.equals(parClassCLGrid2D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid2D)(erg2D), (Grid2D) (clerg2D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 						
 //					Ergebnis ist ein 3DGrid		
 					} else if (ergStr2D.equals(parClassGrid3D) && clergStr2D.equals(parClassCLGrid3D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid3D)(erg2D), (Grid3D) (clerg2D))));
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
-//					Ergebnis ist ein float
-					} else if (ergStr2D.equals(parClassFloat) && clergStr2D.equals(parClassFloat)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg2D) - (Float) (clerg2D),2), Math.pow((Float) (erg2D) - (Float) (clerg2D),2) < smallValue);
-//					Ergebnis ist ein double
-					} else if (ergStr2D.equals(parClassDouble) && clergStr2D.equals(parClassDouble)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg2D) - (Double) (clerg2D),2), Math.pow((Double) (erg2D) - (Double) (clerg2D),2) < smallValue);
-
+//						Ergebnis ist ein float
+						} else if (ergStr2D.equals(parClassFloat) && clergStr2D.equals(parClassFloat)) {
+							double diff = Math.pow((float)erg2D - (float)clerg2D, 2);
+							Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);						
+//						Ergebnis ist ein double
+						} else if (ergStr2D.equals(parClassDouble) && clergStr2D.equals(parClassDouble)) {
+							double diff = Math.pow((Double)erg2D - (Double)clerg2D, 2);
+							Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);
 					} else {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED.  Result types do not agree or are not defined.", false);
 					}
-					
 				} else {
-					Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Result types do not agree.", false);
+					Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Result types do not agree.", false);
 				}
 			} catch (IllegalAccessException e) {
 				// TODO Auto-generated catch block
@@ -387,7 +370,7 @@ public class OpenCLGridTest {
 			if (methods[i].getName().toLowerCase().contains(new String("selectGridOperator").toLowerCase()))
 				continue;
 
-			System.out.println(methods[i]);
+			System.out.println(formatMethodName(methods[i]));
 			
 			Class<?>[] param = methods[i].getParameterTypes();
 
@@ -436,7 +419,7 @@ public class OpenCLGridTest {
 				// wenn erg = null dann ist methode void
 				if(erg3D == null && clerg3D == null) {
 					double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((NumericGrid)(paramSet3D[0]), (NumericGrid) (clparamSet3D[0]))))/(double)grid3D.getNumberOfElements();
-					Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+					Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 				} else if (erg3D != null && clerg3D != null) {
 					
 					String ergStr3D = erg3D.getClass().getName();
@@ -445,39 +428,38 @@ public class OpenCLGridTest {
 //					Ergebnis ist ein Grid
 					if (ergStr3D.equals(parClassGrid) && clergStr3D.equals(parClassGrid)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((NumericGrid)(erg3D), (NumericGrid) (clerg3D))))/(double)((NumericGrid)(erg3D)).getNumberOfElements();
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 
 //					Ergebnis ist ein 1DGrid		
 					} else if (ergStr3D.equals(parClassGrid1D) && clergStr3D.equals(parClassCLGrid1D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid1D)(erg3D), (Grid1D) (clerg3D))))/(double)((NumericGrid)(erg3D)).getNumberOfElements();
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
 //					Ergebnis ist ein 2DGrid		
 					} else if (ergStr3D.equals(parClassGrid2D) && clergStr3D.equals(parClassCLGrid2D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid2D)(erg3D), (Grid2D) (clerg3D))))/(double)((NumericGrid)(erg3D)).getNumberOfElements();
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 						
 //					Ergebnis ist ein 3DGrid		
 					} else if (ergStr3D.equals(parClassGrid3D) && clergStr3D.equals(parClassCLGrid3D)) {
 						double value = NumericPointwiseOperators.sum(NumericPointwiseOperators.sqrcopy(NumericPointwiseOperators.subtractedBy((Grid3D)(erg3D), (Grid3D) (clerg3D))))/(double)((NumericGrid)(erg3D)).getNumberOfElements();
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + value, Math.abs(value) < smallValue);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Value = " + value, Math.abs(value) < smallValue);
 							
 //					Ergebnis ist ein float
 					} else if (ergStr3D.equals(parClassFloat) && clergStr3D.equals(parClassFloat)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Float) (erg3D) - (Float) (clerg3D),2), Math.pow((Float) (erg3D) - (Float) (clerg3D),2) < smallValue);
-						
+						double diff = Math.pow((float)erg3D - (float)clerg3D, 2);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);						
 //					Ergebnis ist ein double
 					} else if (ergStr3D.equals(parClassDouble) && clergStr3D.equals(parClassDouble)) {
-						// TODO: Check here: this test is not working, but the results are correct
-						//Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Value = " + Math.pow((Double) (erg3D) - (Double) (clerg3D),2), Math.pow((Double) (erg3D) - (Double) (clerg3D),2) < smallValue);
+						double diff = Math.pow((Double)erg3D - (Double)clerg3D,2);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. diff = " + diff, diff < smallValue);
 
 					} else {
-						Assert.assertTrue("The test for the method " + methods[i] +" FAILED.  Result types do not agree or are not defined.", false);
+						Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED.  Result types do not agree or are not defined.", false);
 					}
 					
 				} else {
-					Assert.assertTrue("The test for the method " + methods[i] +" FAILED. Result types do not agree.", false);
+					Assert.assertTrue("The test for the method " + formatMethodName(methods[i]) +" FAILED. Result types do not agree.", false);
 				}
 			} catch (IllegalAccessException  e) {
 				// TODO Auto-generated catch block
@@ -491,6 +473,22 @@ public class OpenCLGridTest {
 			}
 
 		}
+	}
+	
+	private String formatMethodName(Method method) {
+		
+		String name = method.getName();
+		int parameterCount = method.getParameterCount();
+		Class<?>[] parameters = method.getParameterTypes();
+		
+		String parameterString = parameters[0].getSimpleName();
+		
+		for (int i = 1; i<parameterCount; i++) {
+			parameterString += ", " + parameters[i].getSimpleName();
+		}
+		
+		return name + "(" + parameterString + ")";
+		
 	}
 
 }

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/PointwiseOperators.cl
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/PointwiseOperators.cl
@@ -3,7 +3,7 @@
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 
-#define LOCAL_GROUP_XDIM 256
+//#define LOCAL_GROUP_XDIM 256
 
 /* Sum of all entries in grid stored in result */
 kernel void sum(global float *grid, global float *result, const unsigned int num_elements, local float *cache)
@@ -35,7 +35,7 @@ kernel void stddev(global float *grid, global float *result, float const mean, i
     const uint group_id = get_group_id(0);
     const uint local_size = get_local_size(0);
     
-    cache[local_id] = (global_id < num_elements) ? pow( (grid[global_id] - mean) , 2) : 0.0f; // sorry for this monster line
+    cache[local_id] = (global_id < num_elements) ? pow( (grid[global_id] - mean), 2) : 0.0f; // sorry for this monster line
     barrier(CLK_LOCAL_MEM_FENCE);
     
     for (unsigned int s = local_size >> 1; s > 0; s >>= 1) {
@@ -71,26 +71,6 @@ kernel void dotProduct(global const float *gridA, global const float *gridB, glo
 }
 
 
-kernel void dotProduct1(global const float *gridA, global const float *gridB, global float *result, int const numElements)
-{
-    int iGID = get_global_id(0);
-    int totalThreads = get_global_size(0);
-    int workPerThread = (numElements/totalThreads)+1;
-    
-    int offset = 0;
-    offset = iGID*workPerThread;
-    
-    result[iGID] = 0;
-    for(int i = 0; i<workPerThread; ++i)
-    {
-        if(offset +i < numElements)
-        {
-            result[iGID] += (gridB[offset+i]*gridA[offset+i]);
-        }
-    }
-}
-
-
 /* result = max(grid) */
 kernel void maximum(global const float *grid, global float *result, int const num_elements, local float *cache)
 {
@@ -99,7 +79,7 @@ kernel void maximum(global const float *grid, global float *result, int const nu
     const uint group_id = get_group_id(0);
     const uint local_size = get_local_size(0);
     
-    cache[local_id] = (global_id < num_elements) ? grid[global_id] : 0.0f;
+    cache[local_id] = (global_id < num_elements) ? grid[global_id] : -MAXFLOAT;
     barrier(CLK_LOCAL_MEM_FENCE);
     
     for (unsigned int s = local_size >> 1; s > 0; s >>= 1) {
@@ -121,7 +101,7 @@ kernel void minimum(global const float *grid, global float *result, int const nu
     const uint group_id = get_group_id(0);
     const uint local_size = get_local_size(0);
     
-    cache[local_id] = (global_id < num_elements) ? grid[global_id] : 0.0f;
+    cache[local_id] = (global_id < num_elements) ? grid[global_id] : MAXFLOAT;
     barrier(CLK_LOCAL_MEM_FENCE);
     
     for (unsigned int s = local_size >> 1; s > 0; s >>= 1) {

--- a/src/edu/stanford/rsl/conrad/data/numeric/opencl/PointwiseOperators.cl
+++ b/src/edu/stanford/rsl/conrad/data/numeric/opencl/PointwiseOperators.cl
@@ -279,6 +279,30 @@ kernel void power(global float *grid, const float exponent, int const num_elemen
 }
 
 
+/* grid = exp(grid) */
+kernel void expontial(global float *grid, int const num_elements )
+{
+    int global_id = get_global_id(0);
+    
+    if(global_id >= num_elements)
+        return;
+    
+    grid[global_id] = exp(grid[global_id]);
+}
+
+
+/* grid = log(grid) */
+kernel void logarithm(global float *grid, int const num_elements )
+{
+    int global_id = get_global_id(0);
+    
+    if(global_id >= num_elements)
+        return;
+    
+    grid[global_id] = log(grid[global_id]);
+}
+
+
 /* grid = log2(grid) */
 kernel void logarithm2(global float *grid, int const num_elements )
 {

--- a/src/edu/stanford/rsl/conrad/opencl/OpenCLUtil.java
+++ b/src/edu/stanford/rsl/conrad/opencl/OpenCLUtil.java
@@ -77,7 +77,7 @@ public abstract class OpenCLUtil {
 	
 	public static void releaseContext (CLContext context){
 		program = null;
-		render  =null;
+		render = null;
 		simpleObjects = null;
 		yxdraw = null;
 		appendBuffer = null;
@@ -408,7 +408,7 @@ public abstract class OpenCLUtil {
 	}
 
 	public synchronized static void initProgram(CLContext context){
-		if (program==null){
+		if (program == null){
 			try {
 				program = context.createProgram(TestOpenCL.class.getResourceAsStream("bspline.cl")).build();
 			} catch (IOException e) {

--- a/src/edu/stanford/rsl/tutorial/iterative/GridOp.java
+++ b/src/edu/stanford/rsl/tutorial/iterative/GridOp.java
@@ -176,7 +176,7 @@ public final class GridOp {
 	 * @param a
 	 * @return minimum value of grid a
 	 */
-	public static float min(Grid3D a) {
+	public static double min(Grid3D a) {
 		return a.getGridOperator().min(a);
 	}
 
@@ -184,7 +184,7 @@ public final class GridOp {
 	 * @param a
 	 * @return maximum value of grid a
 	 */
-	public static float max(Grid3D a) {
+	public static double max(Grid3D a) {
 		return a.getGridOperator().min(a);
 	}
 


### PR DESCRIPTION
**Solved**
- handed in missing kernels for `log()` and `exp()` (my bad, sorry)
- fixed OpenCL grid operators initialization
- added how to use the `OpenCLGridOperators` in `OpenCLBenchmark`
- added minor improvements to `OpenCLTest.java`
- suggested transition to float all the time.

**Unsolved**
The `dotProduct` OpenCL kernel makes some trouble. In my demo `OpenCLBenchmark` it is working nicely, but not in the JUnit test. I haven't figured out, which one is wrong, the kernel or the JUnit test.

**Discussion**
Is there a reason to use both `float` and `double` in `NumericGridOperator`? In my humble opinion it is sufficient to use either `float` or `double`, not both at the same time for different methods. I am suggesting to use float by this commit. 