### PR TITLE
Removed artifacts caused by very close intersection points when creating a projection phantom of triangle meshes

### DIFF
--- a/src/edu/stanford/rsl/conrad/geometry/AbstractShape.java
+++ b/src/edu/stanford/rsl/conrad/geometry/AbstractShape.java
@@ -202,6 +202,18 @@ public abstract class AbstractShape implements Serializable, Transformable {
 	 * @return the intersection points.
 	 */
 	abstract public ArrayList<PointND> intersect(AbstractCurve other);
+	
+	
+	/**
+	 * For most objects this method simply calls intersect(other);
+	 * For triangles the orientation of the hit (scalar product of ray and triangle's normal vectors) is stored as an additional coordinate
+	 * 
+	 * @param other
+	 * @return the intersection points
+	 */
+	public ArrayList<PointND> intersectWithHitOrientation(AbstractCurve other) {
+		return intersect(other);
+	}
 
 	/**
 	 * Rasters the shape with a given number of points or less. If the shape is not bounded null is returned.

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/compound/CompoundShape.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/compound/CompoundShape.java
@@ -83,6 +83,21 @@ public class CompoundShape extends AbstractShape implements Collection<AbstractS
 		}
 		return pts;
 	}
+	
+	protected static ArrayList<PointND> intersectWithHitOrientation(AbstractShape t, AbstractCurve other){
+		ArrayList<PointND> pts = null;
+		if (t instanceof CompoundShape){
+			CompoundShape compound = (CompoundShape) t;
+			if (compound.getHitsOnBoundingBox(other).size() > 0){
+				pts = compound.intersectWithHitOrientation(other);
+			} else {
+				pts = new ArrayList<PointND>();
+			}
+		} else {
+			 pts = t.intersectWithHitOrientation(other);
+		}
+		return pts;
+	}
 
 	@Override
 	public ArrayList<PointND> intersect(AbstractCurve other) {
@@ -92,6 +107,20 @@ public class CompoundShape extends AbstractShape implements Collection<AbstractS
 		ArrayList <PointND> hits = new ArrayList<PointND>();
 		for(AbstractShape t: list){
 			hits.addAll(intersect(t,other));
+		}
+		return hits;
+	}
+	
+	
+
+	@Override
+	public ArrayList<PointND> intersectWithHitOrientation(AbstractCurve other) {
+		if (dirty){
+			init();
+		}
+		ArrayList <PointND> hits = new ArrayList<PointND>();
+		for(AbstractShape t: list){
+			hits.addAll(intersectWithHitOrientation(t, other));
 		}
 		return hits;
 	}

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/compound/TriangleMesh.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/compound/TriangleMesh.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2010-2015 Benedikt Lorch
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+package edu.stanford.rsl.conrad.geometry.shapes.compound;
+
+/**
+ * As a specific compound shape, the triangle mesh encapsulates triangles (which may be nested in another compound shape) imported from an STL file
+ *
+ */
+public class TriangleMesh extends CompoundShape {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -3125319663316060402L;
+	
+}

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/simple/Triangle.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/simple/Triangle.java
@@ -98,8 +98,7 @@ public class Triangle extends Plane3D {
 		return evaluate(cUcoord, cVcoord);
 	}
 
-	@Override
-	public PointND intersect(StraightLine other) {
+	public PointND intersectWithHitOrientation(StraightLine other) {
 		PointND revan = super.intersect(other);
 		//System.out.println(revan);
 		if (isInTriangle(revan)){
@@ -121,6 +120,17 @@ public class Triangle extends Plane3D {
 			return null;
 		}
 	}
+	
+	@Override
+	public PointND intersect(StraightLine other) {
+		PointND revan = super.intersect(other);
+		//System.out.println(revan);
+		if (isInTriangle(revan)){
+			return revan;
+		} else {
+			return null;
+		}
+	}
 
 	@Override
 	public ArrayList<PointND> intersect(AbstractCurve other) {
@@ -128,6 +138,39 @@ public class Triangle extends Plane3D {
 			try {
 				ArrayList<PointND> list = new ArrayList<PointND>();
 				PointND p = intersect((StraightLine) other);
+				if (p!= null) list.add(p);
+				return list;
+			} catch (RuntimeException e){
+				if (e.getLocalizedMessage().equals("Line is parallel to plane")){
+					ArrayList<PointND> list = new ArrayList<PointND>();
+					Edge one = new Edge(getA(), getB());
+					PointND p = one.intersect((StraightLine) other);
+					if (p != null) list.add(p);
+					one = new Edge(getB(), getC());
+					p = one.intersect((StraightLine) other);
+					if (p != null) list.add(p);
+					one = new Edge(getA(), getC());
+					p = one.intersect((StraightLine) other);
+					if (p != null) list.add(p);
+					return list;
+				} else {
+					throw(e);
+				}
+			}
+		} else {
+			throw new RuntimeException("Not implemented yet!");
+		}
+	}
+	
+	/**
+	 * Copy of intersect method which calls intersectWithHitOrientation instead of intersect
+	 */
+	@Override
+	public ArrayList<PointND> intersectWithHitOrientation(AbstractCurve other) {
+		if (other instanceof StraightLine) {
+			try {
+				ArrayList<PointND> list = new ArrayList<PointND>();
+				PointND p = intersectWithHitOrientation((StraightLine) other);
 				if (p!= null) list.add(p);
 				return list;
 			} catch (RuntimeException e){

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/simple/Triangle.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/simple/Triangle.java
@@ -1,12 +1,16 @@
 package edu.stanford.rsl.conrad.geometry.shapes.simple;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import edu.stanford.rsl.conrad.geometry.AbstractCurve;
 import edu.stanford.rsl.conrad.geometry.AbstractShape;
+import edu.stanford.rsl.conrad.geometry.General;
 import edu.stanford.rsl.conrad.geometry.transforms.Transform;
 import edu.stanford.rsl.conrad.numerics.SimpleOperators;
 import edu.stanford.rsl.conrad.numerics.SimpleVector;
+import edu.stanford.rsl.conrad.utils.Configuration;
+import edu.stanford.rsl.conrad.utils.RegKeys;
 
 /**
  * Class to describe a triangle in 3D.
@@ -22,6 +26,7 @@ public class Triangle extends Plane3D {
 	private static final long serialVersionUID = 3360323076084779150L;
 	protected double bUcoord, bVcoord;
 	protected double cUcoord, cVcoord;
+	protected double raytracingEpsilon;	// used to allow a certain tolerance on the decision whether the intersection point of a ray with the 3-D plane lies within the triangle 
 
 	/**
 	 * Creates a new Triangle from the Points a, b, and c
@@ -36,6 +41,8 @@ public class Triangle extends Plane3D {
 		cUcoord = 0;
 		cVcoord = 1;
 		updateBounds(a, b, c);
+		setRaytracingEpsilonFromRegistry();
+		 
 	}
 
 	public Triangle(Triangle shape){
@@ -44,6 +51,22 @@ public class Triangle extends Plane3D {
 		bVcoord = shape.bVcoord;
 		cUcoord = shape.cUcoord;
 		cVcoord = shape.cVcoord;
+		setRaytracingEpsilonFromRegistry();
+	}
+	
+	
+	/**
+	 * Retrieve the raytracing epsilon from global registry.
+	 * If there is no such entry, set the raytracing epsilon to zero.
+	 */
+	private void setRaytracingEpsilonFromRegistry() {
+		HashMap<String, String> registry = Configuration.getGlobalConfiguration().getRegistry();
+		if (registry.containsKey(RegKeys.PHANTOM_PROJECTOR_RAYTRACING_EPSILON)) {
+			raytracingEpsilon = Double.valueOf(Configuration.getGlobalConfiguration().getRegistry().get(RegKeys.PHANTOM_PROJECTOR_RAYTRACING_EPSILON));
+		} else {
+			raytracingEpsilon = 0.d;
+		}
+		
 	}
 
 	@Override
@@ -80,6 +103,19 @@ public class Triangle extends Plane3D {
 		PointND revan = super.intersect(other);
 		//System.out.println(revan);
 		if (isInTriangle(revan)){
+			
+			// Compute the signum between the ray hitting the triangle and the triangle's orientation
+			double hitOrientation = SimpleOperators.multiplyInnerProd(normalN, other.direction);
+			// If the result is smaller than 0, the normal of the triangle is pointing into direction opposed to the ray's direction. It's likely that we enter the object
+			// If the result is greater than 0, the normal of the triangle is pointing into the same direction as the ray. It's likely that we just left the object.
+			
+			// We put the computed orientation as another coordinate into the point of intersection
+			double[] coordinates = revan.getCoordinates();
+			double[] coordinatesHit = new double[coordinates.length + 1];
+			System.arraycopy(coordinates, 0, coordinatesHit, 0, coordinates.length);
+			coordinatesHit[coordinatesHit.length - 1] = hitOrientation;
+			
+			revan = new PointND(coordinatesHit); 
 			return revan;
 		} else {
 			return null;
@@ -118,6 +154,7 @@ public class Triangle extends Plane3D {
 
 	/**
 	 * Computes whether the given point is inside of the triangle. Implementation is based on barycentric coordinates.
+	 * Allows a certain tolerance which is defined in the registry and retrieved in the triangle's constructor.
 	 *  
 	 * @param p the point
 	 * @return true if it is inside of the triangle.
@@ -139,8 +176,9 @@ public class Triangle extends Plane3D {
 		double invDenom = 1.0 / ((dot00 * dot11) - (dot01 * dot01));
 		double u = ((dot11 * dot02) - (dot01 * dot12)) * invDenom;
 		double v = ((dot00 * dot12) - (dot01 * dot02)) * invDenom;
-		return (u >= 0) && (v >= 0) && (u + v <= 1);
+		return (u >= 0 - raytracingEpsilon) && (v >= 0 - raytracingEpsilon) && (u + v <= 1 + raytracingEpsilon);
 	}
+	
 
 	public PointND[] getRasterPoints(int number){
 		Edge one = new Edge (getA(), getB());

--- a/src/edu/stanford/rsl/conrad/io/STLFileUtil.java
+++ b/src/edu/stanford/rsl/conrad/io/STLFileUtil.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import edu.stanford.rsl.conrad.geometry.AbstractShape;
 import edu.stanford.rsl.conrad.geometry.shapes.compound.CompoundShape;
+import edu.stanford.rsl.conrad.geometry.shapes.compound.TriangleMesh;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.PointND;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.Triangle;
 import edu.stanford.rsl.conrad.numerics.SimpleOperators;
@@ -111,7 +112,7 @@ public class STLFileUtil {
 	public static CompoundShape readSTLMesh(String filename, int subCompoundStep) throws IOException{
 		BufferedReader br = new BufferedReader(new FileReader(filename));
 		String lineString = br.readLine();
-		CompoundShape mesh = new CompoundShape();
+		CompoundShape mesh = new TriangleMesh();
 		if (lineString.startsWith("solid")){
 			int currentCount = 0;
 			CompoundShape currentShape = new CompoundShape();

--- a/src/edu/stanford/rsl/conrad/physics/PhysicalObject.java
+++ b/src/edu/stanford/rsl/conrad/physics/PhysicalObject.java
@@ -71,6 +71,10 @@ public class PhysicalObject implements Serializable{
 		return shape.intersect(curve);
 	}
 	
+	public ArrayList<PointND> intersectWithHitOrientation(AbstractCurve curve){
+		return shape.intersectWithHitOrientation(curve);
+	}
+	
 	public void applyTransform(Transform t){
 		shape.applyTransform(t);
 	}

--- a/src/edu/stanford/rsl/conrad/physics/PhysicalPoint.java
+++ b/src/edu/stanford/rsl/conrad/physics/PhysicalPoint.java
@@ -11,6 +11,7 @@ public class PhysicalPoint extends SortablePoint {
 	 */
 	private static final long serialVersionUID = 1259588295137355141L;
 	private PhysicalObject object;
+	protected double hitOrientation;	// used to determine from which direction a triangle has hit the ray
 
 	public PhysicalPoint(PointND p) {
 		super(p);
@@ -39,9 +40,20 @@ public class PhysicalPoint extends SortablePoint {
 	}
 	
 	
+	public double getHitOrientation() {
+		return hitOrientation;
+	}
+
+	
+	public void setHitOrientation(double hitOrientation) {
+		this.hitOrientation = hitOrientation;
+	}
+
+	
 	public boolean equals(PhysicalPoint p){
 		return super.equals(p) && (object.equals(p.object));
-	}
+	}	
+	
 }
 /*
  * Copyright (C) 2010-2014 Andreas Maier

--- a/src/edu/stanford/rsl/conrad/rendering/AbstractRayTracer.java
+++ b/src/edu/stanford/rsl/conrad/rendering/AbstractRayTracer.java
@@ -1,13 +1,20 @@
 package edu.stanford.rsl.conrad.rendering;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
 
 import edu.stanford.rsl.conrad.geometry.AbstractCurve;
+import edu.stanford.rsl.conrad.geometry.AbstractShape;
+import edu.stanford.rsl.conrad.geometry.shapes.compound.CompoundShape;
+import edu.stanford.rsl.conrad.geometry.shapes.compound.TriangleMesh;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.PointND;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.ProjectPointToLineComparator;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.StraightLine;
+import edu.stanford.rsl.conrad.geometry.shapes.simple.Triangle;
 import edu.stanford.rsl.conrad.numerics.SimpleOperators;
 import edu.stanford.rsl.conrad.numerics.SimpleVector;
 import edu.stanford.rsl.conrad.physics.PhysicalObject;
@@ -31,6 +38,9 @@ public abstract class AbstractRayTracer {
 	 * Inconsistent data correction will slow down the projection process, but will help to correct for problems in the data like an uneven number of hits of an object.
 	 */
 	protected boolean inconsistentDataCorrection = true;
+	
+	// Cache the information whether an object is a triangle or not
+	private HashMap<PhysicalObject, Boolean> objIsTriangleCache = new HashMap<>();
 
 	/**
 	 * @return the scene
@@ -74,14 +84,22 @@ public abstract class AbstractRayTracer {
 			if (!foundMore) doubles = false;
 		}
 		if (rayList.size() > 0){
-			PhysicalPoint [] points =  new PhysicalPoint[rayList.size()];
 
 			// sort the points along the ray direction in ascending or descending order
 			ProjectPointToLineComparator clone = comparator.clone();
 			clone.setProjectionLine((StraightLine) ray);
 			Collections.sort(rayList, clone);
-			points = rayList.toArray(points);
 
+			// filter consecutive points entering or leaving the object
+			rayList = filterDoubles(rayList);
+			if (rayList.size() == 0) {
+				return null;
+			}
+			
+			PhysicalPoint [] points =  new PhysicalPoint[rayList.size()];
+			points = rayList.toArray(points);
+			
+			
 			if (inconsistentDataCorrection){
 				ArrayList<PhysicalObject> objects = new ArrayList<PhysicalObject>();
 				ArrayList<Integer> count = new ArrayList<Integer>();
@@ -152,7 +170,13 @@ public abstract class AbstractRayTracer {
 					}
 				}
 			}
+			
+			if (points.length == 0) {
+				return null;
+			}
+			
 			return computeMaterialIntersectionSegments(points);
+
 		} else {
 			return null;
 		}
@@ -177,19 +201,52 @@ public abstract class AbstractRayTracer {
 		for (PhysicalObject shape: scene) {
 			if (shape.getShape().getHitsOnBoundingBox(ray).size()>0) {
 				ArrayList<PointND> intersection = shape.intersect(ray);
+				
 				if (intersection != null && intersection.size() > 0){ 
 					for (PointND p : intersection){
-						PhysicalPoint point = new PhysicalPoint(p);
+						
+						PhysicalPoint point;
+						// Clean coordinates of intersecting points with triangles, as the last coordinate is abused to return the inclination of the triangle
+						if (objIsTriangle(shape)) {
+							point = cleanTriangleIntersection(p);
+						} else {
+							point = new PhysicalPoint(p);
+						}
+						
 						point.setObject(shape);
 						rayList.add(point);
 					}
 					if(intersection.size() == 1) {
-						PhysicalPoint point = new PhysicalPoint(SimpleOperators.add(intersection.get(0).getAbstractVector(), smallIncrementAlongRay));
+						PointND p = intersection.get(0);
+						PhysicalPoint point;
+						
+						// When creating an opposing point, use the negative inclination
+						if (objIsTriangle(shape)) {
+							PhysicalPoint clean = cleanTriangleIntersection(p);
+							p = new PointND(clean.getAbstractVector());
+							point = new PhysicalPoint(SimpleOperators.add(p.getAbstractVector(), smallIncrementAlongRay));
+							point.setHitOrientation(-clean.getHitOrientation());
+						} else {
+							point = new PhysicalPoint(SimpleOperators.add(p.getAbstractVector(), smallIncrementAlongRay));
+						}
+						
 						point.setObject(shape);
 						rayList.add(point);
 					}
 					else if(intersection.size() == 3) {
-						PhysicalPoint point = new PhysicalPoint(SimpleOperators.add(intersection.get(1).getAbstractVector(), smallIncrementAlongRay));
+						PointND p = intersection.get(1);
+						PhysicalPoint point;
+						
+						// Same as above
+						if (objIsTriangle(shape)) {
+							PhysicalPoint clean = cleanTriangleIntersection(p);
+							p = new PointND(clean.getAbstractVector());
+							point = new PhysicalPoint(SimpleOperators.add(p.getAbstractVector(), smallIncrementAlongRay));
+							point.setHitOrientation(-clean.getHitOrientation());
+						} else {
+							point = new PhysicalPoint(SimpleOperators.add(p.getAbstractVector(), smallIncrementAlongRay));
+						}
+						
 						point.setObject(shape);
 						rayList.add(point);
 					}
@@ -198,8 +255,120 @@ public abstract class AbstractRayTracer {
 		}
 		return rayList;
 	}
+	
 
-
+	/**
+	 * When we hit a triangle, we store the inner product between the direction of the ray and the normal of the triangle to determine whether we just entered or left an object
+	 * Remove the point's abused coordinate and store this information in the physical point object
+	 * @param triangleHit point of intersection between ray and triangle. The point's last coordinate isn't a real coordinate
+	 * @return physical point with clean coordinates, the hit orientation and the object
+	 */
+	private PhysicalPoint cleanTriangleIntersection(PointND triangleHit) {
+		double[] coordinates = triangleHit.getCoordinates();
+		double[] cleanCoordinates = Arrays.copyOf(coordinates, coordinates.length - 1);
+		PhysicalPoint point = new PhysicalPoint(new PointND(cleanCoordinates));
+		point.setHitOrientation(coordinates[coordinates.length - 1]);
+		return point;
+	}
+	
+	
+	/**
+	 * Determines whether the given object is a triangle or is composed out of (and only out of) triangles
+	 * The result is stored in a cache-like hash map such that the result can be quickly retrieved from the map
+	 * @param obj to check
+	 * @return true if the given object is a triangle, a triangle mesh or a compound shape which does not hold other objects than triangles
+	 */
+	private boolean objIsTriangle(PhysicalObject obj) {
+		
+		// First, try to retrieve the cached information
+		if (objIsTriangleCache.containsKey(obj)) {
+			return objIsTriangleCache.get(obj);
+		}
+		
+		AbstractShape shape = obj.getShape();
+		if (shape instanceof Triangle || shape instanceof TriangleMesh) {
+			objIsTriangleCache.put(obj, true);
+			return true;
+		}
+		
+		// do breadth first search on nested compound shapes
+		else if (shape instanceof CompoundShape) {
+			LinkedList<AbstractShape> queue = new LinkedList<>();
+			queue.add(shape);
+			
+			while(queue.size() > 0) {
+				CompoundShape cs = (CompoundShape) queue.poll();
+				
+				for (int i=0; i<cs.getInternalDimension(); i++) {
+					shape = cs.get(i);
+					if (shape instanceof Triangle || shape instanceof TriangleMesh) {
+						continue;
+					} else if (shape instanceof CompoundShape) {
+						queue.add(shape);
+					} else {
+						objIsTriangleCache.put(obj, false);
+						return false;
+					}
+				}
+			}
+			
+			// if all the nested compound shapes do not hold more than triangles in the end, we're certainly dealing with a triangle
+			objIsTriangleCache.put(obj, true);
+			return true;
+		}
+		
+		// otherwise it is another shape and thus not a triangle
+		objIsTriangleCache.put(obj, false);
+		return false;
+	}
+	
+	
+	/**
+	 * A ray is supposed to enter and leave a closed object composed out of triangles in an alternating order. If the ray e.g. enters the object twice, it's likely that the two intersections considered as entry are very close.
+	 * An intersecting point is considered an entry if the dot product of the ray's direction and the hit triangle's normal vector is smaller than 0
+	 * @param rayList list of points where the ray intersects with an object
+	 * @return
+	 */
+	private ArrayList<PhysicalPoint> filterDoubles(ArrayList<PhysicalPoint> rayList) {
+		ArrayList<PhysicalPoint> filtered = new ArrayList<>();
+		
+		// First intersection enters the object
+		boolean nextEntersObject = true;
+		boolean init = false;
+		for (int i=0; i<rayList.size(); i++) {
+			PhysicalPoint p = rayList.get(i);
+			
+			// Only for triangles
+			if (!objIsTriangle(p.getObject())) {
+				filtered.add(p);
+				continue;
+			}
+			
+			if (!init) {
+				nextEntersObject = !(p.getHitOrientation() < 0);
+				filtered.add(p);
+				init = true;
+			}
+			else if (nextEntersObject && p.getHitOrientation() < 0) {
+				// Ray enters the object
+				filtered.add(p);
+				nextEntersObject = false;	// alternate
+			}
+			else if (!nextEntersObject && p.getHitOrientation() > 0) {
+				// Ray leaves the object
+				filtered.add(p);
+				nextEntersObject = true;	// alternate
+			}
+			else if (p.getHitOrientation() == 0) {
+				// Ray is parallel to the triangle's surface
+				filtered.add(p);
+			}
+			
+			// if we come to here, the point is discarded
+		}
+		
+		return filtered;
+	}
 
 
 }

--- a/src/edu/stanford/rsl/conrad/rendering/AbstractRayTracer.java
+++ b/src/edu/stanford/rsl/conrad/rendering/AbstractRayTracer.java
@@ -199,8 +199,8 @@ public abstract class AbstractRayTracer {
 		SimpleVector smallIncrementAlongRay = SimpleOperators.subtract(ray.evaluate(CONRAD.SMALL_VALUE).getAbstractVector(), ray.evaluate(0).getAbstractVector());
 		// compute ray intersections:
 		for (PhysicalObject shape: scene) {
-			if (shape.getShape().getHitsOnBoundingBox(ray).size()>0) {
-				ArrayList<PointND> intersection = shape.intersect(ray);
+			if (shape.getShape().getHitsOnBoundingBox(ray).size() > 0) {
+				ArrayList<PointND> intersection = shape.intersectWithHitOrientation(ray);
 				
 				if (intersection != null && intersection.size() > 0){ 
 					for (PointND p : intersection){

--- a/src/edu/stanford/rsl/conrad/utils/RegKeys.java
+++ b/src/edu/stanford/rsl/conrad/utils/RegKeys.java
@@ -271,6 +271,14 @@ public abstract class RegKeys {
 	 * 
 	 */
 	public static final String MSL_DATA_LOCATION = "MSL_DATA_LOCATION";
+	
+	/**
+	 * Entry to define a small accuracy tolerance when deciding whether the point of intersection between ray and triangle lies within the triangle.
+	 * The <b>value</b> is a <b>Double</b> defining the tolerance.
+	 * 
+	 * @see edu.stanford.rsl.conrad.geometry.shapes.simple.Triangle
+	 */
+	public static final String PHANTOM_PROJECTOR_RAYTRACING_EPSILON = "PHANTOM_PROJECTOR_RAYTRACING_EPSILON";
 		
 	public static final HashMap<String,String> defaultValues;
 


### PR DESCRIPTION
Compute the scalar product of the ray's direction and the triangle's normal vector. Assuming that all normal vectors point out of the object, we can decide whether the ray enters or leaves the object. The result is temporarily stored as another coordinate of the intersection point and later interpreted and cleaned by the ray tracer.

Allow a certain tolerance on the decision whether the intersection point of a ray with the 3-D plane lies within the triangle. This little epsilon is read from global registry.

Before:
![image001](https://cloud.githubusercontent.com/assets/11959715/7178688/02c9bf5a-e431-11e4-8e3f-806e618bca62.png)

After:
![image003](https://cloud.githubusercontent.com/assets/11959715/7178689/066d90c8-e431-11e4-944a-1e3b658e7658.png)
