### PR TITLE
Renamed and changed order of parameters of addInterpolateLinear methods

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/InterpolationOperators.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/InterpolationOperators.java
@@ -28,6 +28,7 @@ public abstract class InterpolationOperators {
 		if (grid == null) return 0;
 		if (x < 0 || x > grid.getSize()[0]-1 || y < 0 || y > grid.getSize()[1]-1)
 			return 0;
+		
 		int lower = (int) Math.floor(y);
 		double d = y - lower; // d is in [0, 1)
 
@@ -55,29 +56,27 @@ public abstract class InterpolationOperators {
 	///////////////////////////////////////////////////////////////////////
 
 	/** Linear extrapolation into a 1D Grid */
-	public static void addInterpolateLinear(final Grid1D grid, double i, float val) {
-		int lower = (int) Math.floor(i);
-		double d = i - lower;
+	public static void addInterpolateLinear(final Grid1D grid, double x, float val) {
+		int lower = (int) Math.floor(x);
+		double d = x - lower;
 		grid.setAtIndex(lower, grid.getAtIndex(lower) + (float) ((1.0-d)*val));
 		if (d != 0.0) grid.setAtIndex(lower+1, grid.getAtIndex(lower+1) + (float) (d*val));
 	}
 
 	/** Linear extrapolation into a 2D Grid */
-	public static void addInterpolateLinear(final Grid2D grid, double i, double j, float val) {
-		int lower = (int) Math.floor(i);
-		double d = i - lower;
-		addInterpolateLinear(grid.getSubGrid(lower), j, (float) ((1.0-d)*val));
-		if (d != 0.0) addInterpolateLinear(grid.getSubGrid(lower+1), j, (float) (d*val));
+	public static void addInterpolateLinear(final Grid2D grid, double x, double y, float val) {
+		int lower = (int) Math.floor(y);
+		double d = y - lower;
+		addInterpolateLinear(grid.getSubGrid(lower), x, (float) ((1.0-d)*val));
+		if (d != 0.0) addInterpolateLinear(grid.getSubGrid(lower+1), x, (float) (d*val));
 	}
-
+	
 	/** Linear extrapolation into a 3D Grid */
-	public static void addInterpolateLinear(final Grid3D grid, double i, double j, double k, float val) {
-		int lower = (int) Math.floor(i);
-		double d = i - lower;
-		addInterpolateLinear(grid.getSubGrid(lower), j, k, (float) ((1.0-d)*val));
-		if (d != 0.0) addInterpolateLinear(grid.getSubGrid(lower+1), j, k, (float) (d*val));
+	public static void addInterpolateLinear(final Grid3D grid, double x, double y, double z, float val) {
+		int lower = (int) Math.floor(z);
+		double d = z - lower;
+		addInterpolateLinear(grid.getSubGrid(lower), x, y, (float) ((1.0-d)*val));
+		if (d != 0.0) addInterpolateLinear(grid.getSubGrid(lower+1), x, y, (float) (d*val));
 	}
-
-
 }
 

--- a/src/edu/stanford/rsl/conrad/physics/detector/XRayDetector.java
+++ b/src/edu/stanford/rsl/conrad/physics/detector/XRayDetector.java
@@ -144,8 +144,7 @@ public class XRayDetector extends PhysicalObject implements GUIConfigurable, Ser
 			//pixel outside of the grid
 			//System.err.println("XRayDetector: pixel outside: " + pixel.getElement(0) + ", " +  pixel.getElement(1));
 		} else {
-			//TODO addInterpolateLinear() rows and columns are inverted
-			InterpolationOperators.addInterpolateLinear(grid, (int)pixel.getElement(1), (int)pixel.getElement(0), (float)energy);
+			InterpolationOperators.addInterpolateLinear(grid, (int)pixel.getElement(0), (int)pixel.getElement(1), (float)energy);
 		}
 			
 	}

--- a/src/edu/stanford/rsl/tutorial/cone/ConeBeamProjector.java
+++ b/src/edu/stanford/rsl/tutorial/cone/ConeBeamProjector.java
@@ -68,21 +68,16 @@ public class ConeBeamProjector {
 			for (int y = 0; y < imgSizeY - 1; y++) {
 				double yTrans = y * spacingY - originY;
 				for (int z = 0; z < imgSizeZ - 1; z++) {
-					SimpleVector point3d = new SimpleVector(xTrans, yTrans, z
-							* spacingZ - originZ, 1);
+					SimpleVector point3d = new SimpleVector(xTrans, yTrans, z * spacingZ - originZ, 1);
 					// for(int p = 0; p < maxProjs; p++) {
 					int p = projIdx; //
-					SimpleVector point2d = SimpleOperators.multiply(
-							projMats[p].computeP(), point3d);
-					double coordU = point2d.getElement(0)
-							/ point2d.getElement(2);
-					double coordV = point2d.getElement(1)
-							/ point2d.getElement(2);
-					if (coordU >= maxU - 1 || coordV >= maxV - 1 || coordU <= 0
-							|| coordV <= 0)
+					SimpleVector point2d = SimpleOperators.multiply(projMats[p].computeP(), point3d);
+					double coordU = point2d.getElement(0) / point2d.getElement(2);
+					double coordV = point2d.getElement(1) / point2d.getElement(2);
+					if (coordU >= maxU - 1 || coordV >= maxV - 1 || coordU <= 0 || coordV <= 0)
 						continue;
 					float val = grid.getAtIndex(x, y, z);
-					InterpolationOperators.addInterpolateLinear(sino, coordV, coordU, val); //
+					InterpolationOperators.addInterpolateLinear(sino, coordU, coordV, val); //
 					// }
 				}
 			}
@@ -122,7 +117,7 @@ public class ConeBeamProjector {
 						if (coordU >= maxU-1 || coordV>= maxV -1 || coordU <=0 || coordV <= 0)
 							continue;
 						float val = grid.getAtIndex(x, y, z);
-						InterpolationOperators.addInterpolateLinear(sino, p, coordV, coordU,  val);
+						InterpolationOperators.addInterpolateLinear(sino, coordU, coordV, p, val);
 					}
 				}
 			}

--- a/src/edu/stanford/rsl/tutorial/truncation/ConstantValueZeroArtifactImage.java
+++ b/src/edu/stanford/rsl/tutorial/truncation/ConstantValueZeroArtifactImage.java
@@ -56,12 +56,12 @@ public class ConstantValueZeroArtifactImage extends Phantom implements Citeable 
 		for (int i = 0; i<sizeX; i++){
 			double j = Math.sqrt(-Math.pow(i-sizeX/2.0, 2)+Math.pow((truncationDiameter+1)-sizeX/2.0, 2));
 			if (Double.isNaN(j)) continue;
-			InterpolationOperators.addInterpolateLinear(this, (sizeX/2.0 - j), i, -value);
-			InterpolationOperators.addInterpolateLinear(this, (sizeX/2.0 + j), i, -value);
+			InterpolationOperators.addInterpolateLinear(this, i, (sizeX/2.0 - j), -value);
+			InterpolationOperators.addInterpolateLinear(this, i, (sizeX/2.0 + j), -value);
 			j = Math.sqrt(-Math.pow(i-sizeX/2.0, 2)+Math.pow(truncationDiameter-sizeX/2.0, 2));
 			if (Double.isNaN(j)) continue;
-			InterpolationOperators.addInterpolateLinear(this, (sizeX/2.0 - j), i, value);
-			InterpolationOperators.addInterpolateLinear(this, (sizeX/2.0 + j), i, value);
+			InterpolationOperators.addInterpolateLinear(this, i, (sizeX/2.0 - j), value);
+			InterpolationOperators.addInterpolateLinear(this, i, (sizeX/2.0 + j), value);
 		}
 	}
 	


### PR DESCRIPTION
Changed order of arguments in addInterpolateLinear methods to familiar order, e.g. to (x, y) instead of (y, x). Checked calling methods and changed order of parameters if it seemed like the caller knew that the order was twisted. Fixes akmaier/CONRAD#12
Some comments also indicated that this would be necessary one day, e.g. *//TODO addInterpolateLinear() rows and columns are inverted*