### PR TITLE
Add "Render energy dependent attenuation" function in MultiMaterialPhantom3DVolumeRenderer

### DIFF
--- a/data/materials/bonedense.xml
+++ b/data/materials/bonedense.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>1.53</double> 
+  </void> 
+  <void property="name"> 
+   <string>bonedense</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>1.86155</double> 
+     </void> 
+     <void method="put"> 
+      <string>Ca</string> 
+      <double>9.0</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.03426996</double> 
+     </void> 
+     <void method="put"> 
+      <string>Mg</string> 
+      <double>0.04861</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.58842</double> 
+     </void> 
+     <void method="put"> 
+      <string>Na</string> 
+      <double>0.02299</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>6.96</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>3.18991</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.096198</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/bonelight.xml
+++ b/data/materials/bonelight.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>1.12</double> 
+  </void> 
+  <void property="name"> 
+   <string>bonelight</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>1.3211</double> 
+     </void> 
+     <void method="put"> 
+      <string>Cl</string> 
+      <double>0.10635000000000001</double> 
+     </void> 
+     <void method="put"> 
+      <string>Fe</string> 
+      <double>0.055845</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.10280988</double> 
+     </void> 
+     <void method="put"> 
+      <string>K</string> 
+      <double>0.078196</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.46233</double> 
+     </void> 
+     <void method="put"> 
+      <string>Na</string> 
+      <double>0.02299</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>11.92</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>0.03097</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.06413200000000001</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/breastEDP.xml
+++ b/data/materials/breastEDP.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>0.99</double> 
+  </void> 
+  <void property="name"> 
+   <string>breastEDP</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>3.98732</double> 
+     </void> 
+     <void method="put"> 
+      <string>Cl</string> 
+      <double>0.03545</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.10684164</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.42029999999999995</double> 
+     </void> 
+     <void method="put"> 
+      <string>Na</string> 
+      <double>0.02299</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>8.432</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>0.03097</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.06413200000000001</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/liverEDP.xml
+++ b/data/materials/liverEDP.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>1.07</double> 
+  </void> 
+  <void property="name"> 
+   <string>liverEDP</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>1.6693900000000002</double> 
+     </void> 
+     <void method="put"> 
+      <string>Cl</string> 
+      <double>0.0709</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.10280988</double> 
+     </void> 
+     <void method="put"> 
+      <string>K</string> 
+      <double>0.117294</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.42029999999999995</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>11.456</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>0.09290999999999999</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.096198</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/lungEDP.xml
+++ b/data/materials/lungEDP.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>0.20</double> 
+  </void> 
+  <void property="name"> 
+   <string>lungEDP</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>1.26105</double> 
+     </void> 
+     <void method="put"> 
+      <string>Cl</string> 
+      <double>0.10635000000000001</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.10381782</double> 
+     </void> 
+     <void method="put"> 
+      <string>K</string> 
+      <double>0.078196</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.43431</double> 
+     </void> 
+     <void method="put"> 
+      <string>Na</string> 
+      <double>0.04598</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>11.984</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>0.06194</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.096198</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/muscleEDP.xml
+++ b/data/materials/muscleEDP.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture"> 
+  <void property="density"> 
+   <double>1.07</double> 
+  </void> 
+  <void property="name"> 
+   <string>muscleEDP</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>C</string> 
+      <double>1.7174299999999998</double> 
+     </void> 
+     <void method="put"> 
+      <string>Cl</string> 
+      <double>0.03545</double> 
+     </void> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>0.10280988</double> 
+     </void> 
+     <void method="put"> 
+      <string>K</string> 
+      <double>0.156392</double> 
+     </void> 
+     <void method="put"> 
+      <string>N</string> 
+      <double>0.47634000000000004</double> 
+     </void> 
+     <void method="put"> 
+      <string>Na</string> 
+      <double>0.02299</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>11.36</double> 
+     </void> 
+     <void method="put"> 
+      <string>P</string> 
+      <double>0.06194</double> 
+     </void> 
+     <void method="put"> 
+      <string>S</string> 
+      <double>0.096198</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/omnipaque350.xml
+++ b/data/materials/omnipaque350.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<java version="1.7.0" class="java.beans.XMLDecoder">
+ <object class="edu.stanford.rsl.conrad.physics.materials.Mixture">
+  <void property="density">
+   <double>1.209</double>
+  </void>
+  <void property="name">
+   <string>omnipaque350</string>
+  </void>
+  <void property="weightedAtomicComposition">
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition">
+    <void property="compositionTable">
+     <void method="put">
+      <string>C</string>
+      <double>0.2100988746286455</double>
+     </void>
+     <void method="put">
+      <string>H</string>
+      <double>0.13540469897990942</double>
+     </void>
+     <void method="put">
+      <string>I</string>
+      <double>0.3700039735268485</double>
+     </void>
+     <void method="put">
+      <string>N</string>
+      <double>0.04084769960515297</double>
+     </void>
+     <void method="put">
+      <string>O</string>
+      <double>1.0125047532594436</double>
+     </void>
+    </void>
+   </object>
+  </void>
+ </object>
+</java>

--- a/data/materials/titaniumEDP.xml
+++ b/data/materials/titaniumEDP.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Element"> 
+  <void property="atomicNumber"> 
+   <double>22.0</double> 
+  </void> 
+  <void property="atomicWeight"> 
+   <double>47.867</double> 
+  </void> 
+  <void property="density"> 
+   <double>4.51</double> 
+  </void> 
+  <void property="name"> 
+   <string>titaniumEDP</string> 
+  </void> 
+  <void property="symbol"> 
+   <string>Ti</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>Ti</string> 
+      <double>1.0</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/data/materials/waterEDP.xml
+++ b/data/materials/waterEDP.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<java version="1.6.0_20" class="java.beans.XMLDecoder"> 
+ <object class="edu.stanford.rsl.conrad.physics.materials.Compound"> 
+  <void property="density"> 
+   <double>1.01</double> 
+  </void> 
+  <void property="formula"> 
+   <string>H2O</string> 
+  </void> 
+  <void property="name"> 
+   <string>waterEDP</string> 
+  </void> 
+  <void property="weightedAtomicComposition"> 
+   <object class="edu.stanford.rsl.conrad.physics.materials.utils.WeightedAtomicComposition"> 
+    <void property="compositionTable"> 
+     <void method="put"> 
+      <string>H</string> 
+      <double>2.01588</double> 
+     </void> 
+     <void method="put"> 
+      <string>O</string> 
+      <double>16.0</double> 
+     </void> 
+    </void> 
+   </object> 
+  </void> 
+ </object> 
+</java> 

--- a/src/edu/stanford/rsl/conrad/phantom/electrondensity/CrisEDPhantomGUI.java
+++ b/src/edu/stanford/rsl/conrad/phantom/electrondensity/CrisEDPhantomGUI.java
@@ -47,6 +47,7 @@ public class CrisEDPhantomGUI extends JPanel implements ActionListener,ItemListe
 	private JTextComponent insertNameField;
 	private JTextField materialField;
 	private JTextField densityField;
+	//private JTextField bufferedDiameterField;// define the diameter of buffer insert
 	private AbstractButton innerDiskActivator;
 	private AbstractButton outerDiskActivator;
 	private JLabel insertNameLabel;
@@ -55,6 +56,7 @@ public class CrisEDPhantomGUI extends JPanel implements ActionListener,ItemListe
 	private JLabel instructionLabel;
 	private JCheckBox bufferedMaterial;
 	private JLabel bufferedMaterialLabel;
+	//private JLabel bufferedDiameterLabel; // define the diameter of buffer insert
 	private JButton okButton;
 	private JRadioButton currButton;
 
@@ -124,6 +126,11 @@ public class CrisEDPhantomGUI extends JPanel implements ActionListener,ItemListe
 		bufferedMaterialLabel.setToolTipText("Check if material is buffered with water");
 		bufferedMaterial = new JCheckBox();
 		bufferedMaterial.setToolTipText("Check if material is buffered with water");
+		/*bufferedDiameterLabel = new JLabel("Diameter of buffer insert: ");
+		bufferedDiameterLabel.setName("bufferedDiameterLabel");  
+		bufferedDiameterField = new JTextField("5");
+		bufferedDiameterField.setName("materialField"); 
+		bufferedDiameterField.setMinimumSize(new Dimension(100,10));*/
 		//
 		okButton = new JButton("OK");
 		okButton.setName("okButton");
@@ -268,6 +275,7 @@ public class CrisEDPhantomGUI extends JPanel implements ActionListener,ItemListe
 																				.addComponent(insertNameLabel)
 																				.addComponent(materialLabel)
 																				.addComponent(densityLabel)
+																				//.addComponent(bufferedDiameterLabel)
 																				.addComponent(bufferedMaterialLabel))	                            
 																				.addGap(18, 18, 18)
 																				.addGroup(mainPanelLayout.createParallelGroup(GroupLayout.Alignment.LEADING, false)
@@ -379,7 +387,13 @@ public class CrisEDPhantomGUI extends JPanel implements ActionListener,ItemListe
 		if (index == 8){
 			double centralInsertDiameter = Double.parseDouble(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.ED_PHANTOM_CENTERAL_BUFFER_DIAMETER));
 			ins = new Insert(MaterialsDB.getMaterial(material), buffered, centralInsertDiameter);
-		} else {
+		} 
+		//special modification for determining the buffer diameter of Insert1 to adapt Jang@Stanford's EDPhantom 
+		else if (index == 1){
+			double insertOneDiameter = Double.parseDouble(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.ED_PHANTOM_INSERT_1_BUFFER_DIAMETER));
+			ins = new Insert(MaterialsDB.getMaterial(material), buffered, insertOneDiameter);
+		} 
+		else {
 			ins = new Insert(MaterialsDB.getMaterial(material), buffered);
 		}
 		if(ring.equals("I")){

--- a/src/edu/stanford/rsl/conrad/phantom/electrondensity/CrisEDPhantomM062.java
+++ b/src/edu/stanford/rsl/conrad/phantom/electrondensity/CrisEDPhantomM062.java
@@ -33,6 +33,7 @@ public class CrisEDPhantomM062 extends AnalyticPhantom {
 	private boolean useOuterDisk = true;
 	private boolean useBoneRing = true;
 	private double centralInsertDiameter;
+	private double insertOneDiameter;
 	private EDInnerDisk inner = new EDInnerDisk();
 	private EDOuterDisk outer = new EDOuterDisk();
 
@@ -47,6 +48,7 @@ public class CrisEDPhantomM062 extends AnalyticPhantom {
 		super.configure();
 		useBoneRing = Boolean.parseBoolean(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.ED_PHANTOM_BONE_RING));
 		centralInsertDiameter = Double.parseDouble(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.ED_PHANTOM_CENTERAL_BUFFER_DIAMETER));
+		insertOneDiameter = Double.parseDouble(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.ED_PHANTOM_INSERT_1_BUFFER_DIAMETER));
 		for(int i = 0; i < 9; i++){
 			innerDiskIns[i] = new Insert( MaterialsDB.getMaterial("vacuum"), Insert.UNBUFFERED_INSERT);
 		}

--- a/src/edu/stanford/rsl/conrad/phantom/electrondensity/Insert.java
+++ b/src/edu/stanford/rsl/conrad/phantom/electrondensity/Insert.java
@@ -57,7 +57,7 @@ public class Insert extends PrioritizableScene {
 	}
 	
 	public Insert(Material material, int bufferState) {
-		this(material, bufferState, 5);
+		this(material, bufferState, 3);
 	}
 	
 	/**

--- a/src/edu/stanford/rsl/conrad/phantom/workers/MultiMaterialPhantom3DVolumeRenderer.java
+++ b/src/edu/stanford/rsl/conrad/phantom/workers/MultiMaterialPhantom3DVolumeRenderer.java
@@ -13,11 +13,11 @@ import edu.stanford.rsl.conrad.geometry.shapes.simple.PointND;
 import edu.stanford.rsl.conrad.geometry.shapes.simple.StraightLine;
 import edu.stanford.rsl.conrad.geometry.trajectories.Trajectory;
 import edu.stanford.rsl.conrad.geometry.transforms.Translation;
-import edu.stanford.rsl.conrad.numerics.SimpleVector;
 import edu.stanford.rsl.conrad.phantom.AnalyticPhantom;
 import edu.stanford.rsl.conrad.phantom.AnalyticPhantom4D;
 import edu.stanford.rsl.conrad.physics.PhysicalObject;
 import edu.stanford.rsl.conrad.physics.materials.Material;
+import edu.stanford.rsl.conrad.physics.materials.utils.AttenuationType;
 import edu.stanford.rsl.conrad.rendering.AbstractRayTracer;
 import edu.stanford.rsl.conrad.rendering.PrioritizableScene;
 import edu.stanford.rsl.conrad.rendering.Priority1DRayTracer;
@@ -25,6 +25,7 @@ import edu.stanford.rsl.conrad.utils.CONRAD;
 import edu.stanford.rsl.conrad.utils.Configuration;
 import edu.stanford.rsl.conrad.utils.RegKeys;
 import edu.stanford.rsl.conrad.utils.UserUtil;
+import ij.process.FloatProcessor;
 
 
 /**
@@ -35,8 +36,12 @@ import edu.stanford.rsl.conrad.utils.UserUtil;
  * 
  */
 public class MultiMaterialPhantom3DVolumeRenderer extends SliceWorker {
+	protected boolean renderAttenuation = false;
+	protected double xrayEnergy = 80;
 	protected AnalyticPhantom phantom = null;
 	protected PrioritizableScene currentScene = null;
+	private static double DEFAULT_ATTENUATION = -1024; // air(HU)
+	protected AttenuationType attType = AttenuationType.TOTAL_WITH_COHERENT_ATTENUATION;
 
 	@Override
 	public String getProcessName() {
@@ -84,6 +89,7 @@ public class MultiMaterialPhantom3DVolumeRenderer extends SliceWorker {
 			phantomScene = currentScene;
 		}
 		tracer.setScene(phantomScene);
+		
 		// create list of all available materials.
 		ArrayList<Material> materials = new ArrayList<Material>();
 		for (int j=0; j < phantomScene.size(); j++){
@@ -100,10 +106,15 @@ public class MultiMaterialPhantom3DVolumeRenderer extends SliceWorker {
 
 		MultiChannelGrid2D multiChannelGrid2D = new MultiChannelGrid2D(geom.getReconDimensionX(), geom.getReconDimensionY(), materials.size());
 		multiChannelGrid2D.setChannelNames(channelNames);
-
-		for (int c= 0; c<multiChannelGrid2D.getNumberOfChannels();c++){
-			Grid2D slice = new Grid2D(multiChannelGrid2D.getWidth(), multiChannelGrid2D.getHeight());
-			multiChannelGrid2D.setChannel(c, slice);
+		
+		for (int c= 0; c<multiChannelGrid2D.getNumberOfChannels();c++){			
+			FloatProcessor slice = new FloatProcessor(geom.getReconDimensionX(), geom.getReconDimensionY());
+			slice.add(DEFAULT_ATTENUATION);
+			if (renderAttenuation && xrayEnergy > 0)
+				slice.setValue(phantomScene.getBackgroundMaterial().getAttenuation(xrayEnergy,attType)*phantomScene.getBackgroundMaterial().getDensity());
+			else
+				slice.setValue(phantomScene.getBackgroundMaterial().getDensity());
+			slice.fill();
 			double z  = (sliceNumber - originIndexZ) * voxelSizeZ;
 			double xFirst = (-originIndexX) * voxelSizeX;
 			double xLast = (slice.getWidth()-originIndexX) * voxelSizeX;
@@ -129,22 +140,31 @@ public class MultiMaterialPhantom3DVolumeRenderer extends SliceWorker {
 								continue;
 							}
 							int iy = (int) Math.round((y / voxelSizeY) + originIndexY);
-							for (int l = ix1; l < ix2; l++){
-								slice.setAtIndex(l, iy, 1);
-							}
+							if (renderAttenuation && xrayEnergy > 0)
+								slice.setValue(o.getMaterial().getAttenuation(xrayEnergy, attType)*o.getMaterial().getDensity());
+							else
+								slice.setValue(o.getMaterial().getDensity());
+							slice.drawLine(ix1, iy, ix2-1, iy);
 						}
 					}
 					long renderTime = System.currentTimeMillis() - basetime;
 					if (sliceNumber == 123) System.out.println("Cast time " + castTime + " render time " + renderTime + " " + segments.size());
 				}
 			}
+			Grid2D grid = new Grid2D((float[])slice.getPixels(), slice.getWidth(), slice.getHeight());
+			multiChannelGrid2D.setChannel(c, grid);
 		}
+		
 		this.imageBuffer.add(multiChannelGrid2D, sliceNumber);
 	}
 
 	public SliceWorker clone() {
 		MultiMaterialPhantom3DVolumeRenderer newRend = new MultiMaterialPhantom3DVolumeRenderer();
 		newRend.phantom = this.phantom;
+		newRend.attType=attType;
+		newRend.xrayEnergy = xrayEnergy;
+		newRend.renderAttenuation = renderAttenuation;
+		newRend.showStatus = showStatus;
 		return newRend;
 	}
 
@@ -153,13 +173,11 @@ public class MultiMaterialPhantom3DVolumeRenderer extends SliceWorker {
 		super.configure();
 		phantom = UserUtil.queryPhantom("Select Phantom", "Select Phantom");
 		phantom.configure();
+		renderAttenuation = UserUtil.queryBoolean("Render energy dependent attenuation?");
+		if(renderAttenuation)
+			xrayEnergy = UserUtil.queryDouble("Monochromatic Xray energy [keV]", xrayEnergy);
 	}
-
-
-
-
-
-
+	
 }
 /*
  * Copyright (C) 2010-2014 Andreas Maier, Rotimi X Ojo

--- a/src/edu/stanford/rsl/conrad/utils/RegKeys.java
+++ b/src/edu/stanford/rsl/conrad/utils/RegKeys.java
@@ -297,6 +297,13 @@ public abstract class RegKeys {
 	 * The <b>value</b> is a <b>Double</b> defining the diameter in [mm].
 	 */
 	public static final String ED_PHANTOM_CENTERAL_BUFFER_DIAMETER = "ED_PHANTOM_CENTERAL_BUFFER_DIAMETER";
+
+	/**
+	 * Global configuration of the ED Phantom (CRIS M062 Phantom).
+	 * Entry to define a special buffer diameter for the Insert 1.
+	 * The <b>value</b> is a <b>Double</b> defining the diameter in [mm].
+	 */
+	public static final String ED_PHANTOM_INSERT_1_BUFFER_DIAMETER = "ED_PHANTOM_INSERT_1_BUFFER_DIAMETER";
 	
 	/**
 	 * Global configuration of the ED Phantom (CRIS M062 Phantom).


### PR DESCRIPTION
Referenced "AnalyticPhantom3DVolumeRenderer.java".

Some snapshots:
![2015-08-03 12_40_52-java - conrad_src_edu_stanford_rsl_conrad_phantom_workers_multimaterialphantom3d](https://cloud.githubusercontent.com/assets/13233583/9035953/0c4bd9ee-39dd-11e5-8bd4-41cb269f6213.png)
![2015-08-03 12_41_23-java - conrad_src_edu_stanford_rsl_conrad_phantom_workers_multimaterialphantom3d](https://cloud.githubusercontent.com/assets/13233583/9035954/114a07d6-39dd-11e5-9df2-8e284eb5a09c.png)
![2015-08-03 12_41_36-java - conrad_src_edu_stanford_rsl_conrad_phantom_workers_multimaterialphantom3d](https://cloud.githubusercontent.com/assets/13233583/9035956/145e2812-39dd-11e5-8620-923a497251dc.png)
