### PR TITLE
Added the possibility to configure the BilateralFilteringTool...

### DIFF
--- a/src/edu/stanford/rsl/conrad/filtering/BilateralFilteringTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/BilateralFilteringTool.java
@@ -120,6 +120,18 @@ public class BilateralFilteringTool extends IndividualImageFilteringTool {
 		return false;
 	}
 
+	/**
+	 * Allows changing of filter parameters without the need for calling the User-Query dialog. 
+	 * @param width The kernel width
+	 * @param domainSigma The domain standard deviation used for spatial filtering
+	 * @param photometricSigma The photometric standard deviation
+	 */
+	public void setParameters(int width, double domainSigma, double photometricSigma){
+		this.width = width;
+		this.sigma_d = domainSigma;
+		this.sigma_r = photometricSigma;
+	}
+	
 }
 
 /*

--- a/src/edu/stanford/rsl/tutorial/test/MaxThreadsTest.java
+++ b/src/edu/stanford/rsl/tutorial/test/MaxThreadsTest.java
@@ -1,0 +1,26 @@
+package edu.stanford.rsl.tutorial.test;
+
+import edu.stanford.rsl.conrad.utils.CONRAD;
+import edu.stanford.rsl.conrad.utils.Configuration;
+import edu.stanford.rsl.conrad.utils.RegKeys;
+
+public class MaxThreadsTest {
+
+	public static void main(String[] args){
+		
+		// this call should throw an exception
+		int maxThreads = CONRAD.getNumberOfThreads();
+				
+		// this call should retun the number of threads defined
+        CONRAD.setup();
+        // let us check if the number is defined
+        // if it isn't we'll set it manually
+        if(Configuration.getGlobalConfiguration().getRegistryEntry(RegKeys.MAX_THREADS) == null){
+        	Configuration.getGlobalConfiguration().setRegistryEntry(RegKeys.MAX_THREADS, String.valueOf(1));
+        }
+        
+        maxThreads = CONRAD.getNumberOfThreads();
+        System.out.println("Number of Threads is: "+maxThreads);
+	}
+	
+}


### PR DESCRIPTION
Added the possibility to configure the BilateralFilteringTool without need to use a GUI.
Added a test class demonstrating problems arising from not loading the configuration before calling configuration related variables. This is demonstrated using the registry entry related to maximum threads used.