### PR TITLE
Backprojection data lookup now performs zero-padding

### DIFF
--- a/src/edu/stanford/rsl/conrad/opencl/backprojectCL.cl
+++ b/src/edu/stanford/rsl/conrad/opencl/backprojectCL.cl
@@ -3,7 +3,7 @@ typedef float Tcoord_dev;
 typedef float TdetValue;
 
 // Volume texture
-__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_LINEAR;
+__constant sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_LINEAR;
 
 //__constant__ int gVolStride[2];  
 


### PR DESCRIPTION
backprojectCL.cl should not perform clamping to an edge value during backprojection.
This yields a very very bright halo outside the FOV in case of truncated objects.
This commit changes data lookups outside the FOV to return a 0 value.
