### PR TITLE
Minor convenience changes to DataMatrix, PCA, Mesh, and MultiChannelGrid3D. tg.

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/MultiChannelGrid3D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/MultiChannelGrid3D.java
@@ -18,6 +18,8 @@ public class MultiChannelGrid3D extends Grid3D {
 	Grid4D multichannelData;
 	
 	public MultiChannelGrid3D(int width, int height, int depth, int channels) {
+		// This will cause some parent methods to fail ( e.g. getSize() );
+		// TODO Override necessary parent methods.
 		super(0,0,0);
 		multichannelData = new Grid4D(width, height, depth, channels);
 		buffer = multichannelData.getSubGrid(0).getBuffer();
@@ -106,4 +108,11 @@ public class MultiChannelGrid3D extends Grid3D {
 		this.channelNames = channelNames;
 	}
 
+	@Override
+	/**
+	 * @return The array's size (excluding borders).
+	 */
+	public int[] getSize() {
+		return new int[]{this.multichannelData.getSize()[0],this.multichannelData.getSize()[1],this.multichannelData.getSize()[2]};
+	}
 }

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/mesh/DataMatrix.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/mesh/DataMatrix.java
@@ -257,4 +257,22 @@ public class DataMatrix extends SimpleMatrix{
 			
 		}
 	}
+	
+	/**
+	 * Returns the column colIdx of the  {@link DataMatrix} in its original numVertices x dimension {@link SimpleMatrix} form.
+	 * @param colIdx The column index where the linearized matrix is stored.
+	 * @return SimpleMatrix of the form numVertices x dimension.
+	 */
+	public SimpleMatrix getSimpleMatrixAtIndex(int colIdx){
+		assert(colIdx < this.cols) : new IllegalArgumentException("Column index for this mesh is out of bounds.");
+		SimpleMatrix mat = new SimpleMatrix(this.rows/this.dimension, this.dimension);
+			
+		for(int i = 0; i < mat.getRows(); i++){
+			int rowMajor = dimension * i;
+			for(int j = 0; j < dimension; j++){
+				mat.setElementValue(i, j, this.getElement(rowMajor + j, colIdx));
+			}
+		}
+		return mat;
+	}
 }


### PR DESCRIPTION
DataMatrix: Added a getter function to return the column colIdx of the DataMatrix in its original numVertices x dimension SimpleMatrix form.

PCA: Added an applyWeights method expecting weights in the form of double[] instead of float[]. This is more consistent with projectTrainingShape() and other methods that return weights as double arrays.

Mesh: Extended to meshes featuring deformation vectors at each mesh vertex.

MultiChannelGrid3D (inherits from Grid3D): getSize() of parent class overwritten to accomodate for Grid4D member multiChannelData. Now returns the first 3 dimensions of mutliChannelData.getSize() while getNumberOfChannels() returns the 4th.