### PR TITLE
Bug Fixes in Phantom Creator and Duplicate OpenCL Backprojector Name

### DIFF
--- a/src/edu/stanford/rsl/apps/gui/XCatMetricPhantomCreator.java
+++ b/src/edu/stanford/rsl/apps/gui/XCatMetricPhantomCreator.java
@@ -121,7 +121,8 @@ public class XCatMetricPhantomCreator {
 
 			double[] timeList = new double[getSteps()];
 			for (int i = 0; i < timeList.length; i++) {
-				timeList[i]=((double)i)/((double)(getSteps()-1));
+				double steps = (getSteps()==1)?1.0:((double)(getSteps()-1));
+				timeList[i]=((double)i)/steps;
 			}
 
 

--- a/src/edu/stanford/rsl/tutorial/RotationalAngiography/ResidualMotionCompensation/reconWithStreakReduction/OpenCLBackProjectorStreakReduction.java
+++ b/src/edu/stanford/rsl/tutorial/RotationalAngiography/ResidualMotionCompensation/reconWithStreakReduction/OpenCLBackProjectorStreakReduction.java
@@ -673,7 +673,7 @@ public class OpenCLBackProjectorStreakReduction extends VOIBasedReconstructionFi
 
 	@Override
 	public String getToolName(){
-		return "OpenCL Backprojector";
+		return "OpenCL Backprojector with Streak Reduction";
 	}
 
 	/**


### PR DESCRIPTION
Fixed a bug where XCatMetricPhantomCreator would yield a time of NaN if only a single phase was requested.

Fixed a bug in OpenCLBackProjectorStreakReduction where the class was erroneously shown as "OpenCL Back Projector" when configuring the Reconstruction Pipeline using the ReconstructionPipelineFrame.