### PR TITLE
Offset computation in ParkerWeightingTool

### DIFF
--- a/src/edu/stanford/rsl/conrad/filtering/redundancy/ParkerWeightingTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/redundancy/ParkerWeightingTool.java
@@ -208,7 +208,11 @@ public class ParkerWeightingTool extends IndividualImageFilteringTool {
 				if (debug) {
 					System.out.println("Angular Range: " + range * 180 / Math.PI + "\n MaxRange: " + maxRange *180 / Math.PI + "\nProjections: " + primaryAngles.length + " " + numberOfProjections);
 				}
-				//offset = (maxRange - range) /2;
+				
+				// offset has to be computed here
+				// otherwise, it is only computed in the configure() method, which may not be called before
+				offset = (maxRange - range) /2;
+				
 				//offset = 0.001;
 				//delta *= 0.5;
 				//offset -= (0.9 / 180) * Math.PI;


### PR DESCRIPTION
Added the offset computation during the calculation of the ParkerWeights.
Before, the offset has been computed and initialized only if the configure() function is called.
This is not always the case: for example if an existing Conrad.xml is loaded and the configure button is not pushed. This can cause wrong weigths and thus artifacts in the reconstructions.
