### PR TITLE
setSubgrid was not working

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -87,14 +87,33 @@ public class Grid2D extends NumericGrid implements Transformable {
 		return this.buffer;
 	}
 
+	@Deprecated
 	/**
-	 * Returns the corresponding Grid1D object that points on the linear 2D row memory 
-	 * @param j The row-index (y-index, height-index) 
-	 * @return the sub grid
+	 * Set the corresponding Grid1D object on the linear 2D row memory
+	 * 
+	 * CAUTION: We set absolute values and no references.
+	 * If the input Grid1D subGrid is changed at a later point,
+	 * it won't change the values in the Grid2D.
+	 * This is due to "float buffer" nature of Grid2D,
+	 * which is a fundamental difference to the structure of Grid3D,
+	 * which is defined by an ArrayList of Grid2Ds.
+	 * 
+	 * You can do a little workaround, when adding the following code:
+	 * 
+	 * myGrid2D.setSubgrid(j, Grid1D myGrid1D);
+	 * myGrid1D = myGrid2D.getSubGrid(j);
+	 * 
+	 * @param j The row-index (y-index, height-index)
+	 * @param subGrid
 	 */
-	public Grid1D getSubGrid(int j) {
-		notifyBeforeRead();
-		return subGrids[j];
+	public void setSubGrid(int j, Grid1D subGrid) {
+		
+        for (int i=0; i<subGrid.getSize()[0]; ++i) {
+            setAtIndex(j, i, subGrid.getAtIndex(i));
+        }
+       
+        
+        notifyAfterWrite();
 	}
 
 	@Deprecated

--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -102,6 +102,9 @@ public class Grid2D extends NumericGrid implements Transformable {
 	 * 
 	 * myGrid2D.setSubgrid(j, Grid1D myGrid1D);
 	 * myGrid1D = myGrid2D.getSubGrid(j);
+	 *
+	 * This code is deprecated since no final solution was found 
+	 * to solve the prior menioned problem.
 	 * 
 	 * @param j The row-index (y-index, height-index)
 	 * @param subGrid
@@ -113,28 +116,6 @@ public class Grid2D extends NumericGrid implements Transformable {
         }
        
         
-        notifyAfterWrite();
-	}
-
-	@Deprecated
-	/**
-	 * Set the corresponding Grid1D object on the linear 2D row memory
-	 * 
-	 * CAUTION: We set absolute values and no references.
-	 * If the input Grid1D subGrid is changed at a later point,
-	 * it won't change the values in the Grid2D.
-	 * This is due to "float buffer" nature of Grid2D,
-	 * which is a fundamental difference to the structure of Grid3D,
-	 * which is defined by an ArrayList of Grid2Ds.
-	 * 
-	 * @param j The row-index (y-index, height-index)
-	 * @param subGrid
-	 */
-	public void setSubGrid(int j, Grid1D subGrid) {
-		
-        for (int i=0; i<subGrid.getSize()[0]; ++i) {
-            setAtIndex(j, i, subGrid.getAtIndex(i));
-        }
         notifyAfterWrite();
 	}
 	

--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -97,6 +97,27 @@ public class Grid2D extends NumericGrid implements Transformable {
 		return subGrids[j];
 	}
 
+	@Deprecated
+	/**
+	 * Set the corresponding Grid1D object on the linear 2D row memory
+	 * 
+	 * CAUTION: We set absolute values and no references.
+	 * If the input Grid1D subGrid is changed at a later point,
+	 * it won't change the values in the Grid2D.
+	 * This is due to "float buffer" nature of Grid2D,
+	 * which is a fundamental difference to the structure of Grid3D,
+	 * which is defined by an ArrayList of Grid2Ds.
+	 * 
+	 * @param j The row-index (y-index, height-index)
+	 * @param subGrid
+	 */
+	public void setSubGrid(int j, Grid1D subGrid) {
+		
+        for (int i=0; i<subGrid.getSize()[0]; ++i) {
+            setAtIndex(j, i, subGrid.getAtIndex(i));
+        }
+        notifyAfterWrite();
+	}
 	
 	public double[] indexToPhysical(double i, double j) {
 		return new double[] {

--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -87,6 +87,17 @@ public class Grid2D extends NumericGrid implements Transformable {
 		return this.buffer;
 	}
 
+	/**
+	 * Returns the corresponding Grid1D object that points on the linear 2D row memory 
+	 * @param j The row-index (y-index, height-index) 
+	 * @return the sub grid
+	 */
+	public Grid1D getSubGrid(int j) {
+		notifyBeforeRead();
+		return subGrids[j];
+	}
+	
+
 	@Deprecated
 	/**
 	 * Set the corresponding Grid1D object on the linear 2D row memory


### PR DESCRIPTION
setSubGrid was not working since data in the buffer was not written.
Now the float[] buffer is written, which automatically takes care of the subgrid.

Unfortunately the connection/ reference between the input subGrid and the Grid2D is lost.
In other words: In case someone changes the input subGrid, which is not synchronized with Grid2D, the changes are not visible for the Grid2D.