### PR TITLE
Modified constructor of ForbildBox...

### DIFF
--- a/src/edu/stanford/rsl/conrad/phantom/forbild/shapes/ForbildBox.java
+++ b/src/edu/stanford/rsl/conrad/phantom/forbild/shapes/ForbildBox.java
@@ -32,7 +32,9 @@ public class ForbildBox extends Box {
 
 	public ForbildBox(String expression){
 		 parseExpression(expression);
-		 transform = new AffineTransform(new SimpleMatrix(3,3), new SimpleVector(3));
+		 SimpleMatrix rot = new SimpleMatrix(3,3);
+		 rot.identity();
+		 transform = new AffineTransform(rot, new SimpleVector(3));
 		 correctAndAddBoundingConditions();
 		 surfaceOrigin.set(0, surfaceOrigin.get(0)-dx/2);
 		 surfaceOrigin.set(1, surfaceOrigin.get(1)-dy/2);


### PR DESCRIPTION
The constructor used to initialize the affine transformation using an empty SimpleMatrix, yielding a mapping to zero for every applyTransform() call. The scale-rotation matrix is now initialized as identity. tg and mu