### PR TITLE
fftshift() support for ComplexGrid 1-3D classes

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid1D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid1D.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 - Martin Berger
+ * Copyright (C) 2017 - Christopher Syben
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 package edu.stanford.rsl.conrad.data.generic.complex;
@@ -73,14 +74,10 @@ public class ComplexGrid1D extends ComplexGrid {
 	
 	public void fftshift(){
 		int width = this.size[0];
-		int startIndex = offset*2;//offset take alternating complex values into account
+		int startIndex = offset*2;
 		int endIndex = startIndex+(width*2);
-//		[.....][rel im rel im rel im rel im rel im][....]
-//				l								 l
-//				v								 v
-//			startIndex							endIndex
-// endIndex-startIndex = 2* width
 		int pW = (int)Math.ceil(width/2.0); 
+		
 		float[] tmpArr = Arrays.copyOfRange(buffer, startIndex, endIndex);
 		for(int i = pW; i < this.getSize()[0];i++)
 		{

--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid1D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid1D.java
@@ -4,6 +4,8 @@
 */
 package edu.stanford.rsl.conrad.data.generic.complex;
 
+import java.util.Arrays;
+
 import edu.stanford.rsl.conrad.data.generic.datatypes.Complex;
 import edu.stanford.rsl.conrad.data.numeric.Grid1D;
 
@@ -67,6 +69,29 @@ public class ComplexGrid1D extends ComplexGrid {
 	public void init(){
 		this.origin = new double[]{0};
 		this.spacing = new double[]{1};
+	}
+	
+	public void fftshift(){
+		int width = this.size[0];
+		int startIndex = offset*2;//offset take alternating complex values into account
+		int endIndex = startIndex+(width*2);
+//		[.....][rel im rel im rel im rel im rel im][....]
+//				l								 l
+//				v								 v
+//			startIndex							endIndex
+// endIndex-startIndex = 2* width
+		int pW = (int)Math.ceil(width/2.0); 
+		float[] tmpArr = Arrays.copyOfRange(buffer, startIndex, endIndex);
+		for(int i = pW; i < this.getSize()[0];i++)
+		{
+			buffer[startIndex+(i-pW)*2] = tmpArr[(i)*2];
+			buffer[startIndex+(i-pW)*2+1] = tmpArr[(i)*2+1];
+		}
+		for(int i = 0; i < pW;i++)
+		{
+			buffer[startIndex + (i+width-pW)*2] = tmpArr[(i)*2];
+			buffer[startIndex + (i+width-pW)*2+1] = tmpArr[(i)*2+1];
+		}		
 	}
 	
 	public void multiplyAtIndex(int index, float val) {

--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid2D.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 - Martin Berger
+ * Copyright (C) 2017 - Christopher Syben
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 package edu.stanford.rsl.conrad.data.generic.complex;
@@ -76,7 +77,6 @@ public class ComplexGrid2D extends ComplexGrid {
 		for(int i = 0; i < subGrids.length;i++ ){
 			unshifted[i].fftshift();
 		}
-		//size[width,height]
 		int height = this.getSize()[1];
 		int pH = (int)Math.ceil(height/2.0);
 		

--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid2D.java
@@ -70,13 +70,30 @@ public class ComplexGrid2D extends ComplexGrid {
 		}
 	}
 	
+	public void fftshift()
+	{	
+		ComplexGrid1D[] unshifted = subGrids.clone();
+		for(int i = 0; i < subGrids.length;i++ ){
+			unshifted[i].fftshift();
+		}
+		//size[width,height]
+		int height = this.getSize()[1];
+		int pH = (int)Math.ceil(height/2.0);
+		
+		for(int j = pH; j < this.getSize()[1];j++)
+		{
+		 	this.setSubGrid(j-pH,unshifted[j]);
+		}
+		for(int j = 0; j < pH;j++)
+		{
+		 	this.setSubGrid(j+height-pH,unshifted[j]);
+		}
+	}
 	
 	public float[] getBuffer(){
 		notifyBeforeRead();
 		return buffer;
 	}
-	
-	
 	
 	
 	public void multiplyAtIndex(int i, int j, float val) {
@@ -160,6 +177,10 @@ public class ComplexGrid2D extends ComplexGrid {
 		return this.subGrids[j];
 	}
 	
+	public void setSubGrid(int j, ComplexGrid1D collumn){
+		subGrids[j]=collumn;
+		notifyAfterWrite();
+	}
 	
 	@Override
 	public Complex getValue(int... idx) {

--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid3D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid3D.java
@@ -77,7 +77,24 @@ public class ComplexGrid3D extends ComplexGrid {
 		}
 	}
 
-
+	public void fftshift()
+	{
+		ComplexGrid2D[] unshifted = subGrids.clone();
+		for(int i = 0; i < subGrids.length;i++ ){
+			unshifted[i].fftshift();
+		}
+		int depth = this.getSize()[2];
+		int pD = (int)Math.ceil(depth/2.0);		
+		for(int k = pD; k < this.getSize()[2];k++)
+		{
+		 	this.setSubGrid(k-pD,unshifted[k]);
+		}
+		for(int k = 0; k < pD;k++)
+		{
+		 	this.setSubGrid(k+depth-pD,unshifted[k]);
+		}
+	}
+	
 	public float[] getBuffer(){
 		notifyBeforeRead();
 		return buffer;

--- a/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid3D.java
+++ b/src/edu/stanford/rsl/conrad/data/generic/complex/ComplexGrid3D.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 - Martin Berger
+ * Copyright (C) 2017 - Christopher Syben
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 package edu.stanford.rsl.conrad.data.generic.complex;


### PR DESCRIPTION
Added fftshift method to the ComplexGrid classes.
The value shift on the float buffer is applied in the 1D grid. The 2D and the 3D grid classes working on the abstract subgrid construction. 

The suggested implementation provides shift for the 1D, 2D and 3D complexGrid classes.
