### PR TITLE
Minor fixes to Grid classes

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -115,7 +115,7 @@ public class Grid2D extends NumericGrid implements Transformable {
 	 * myGrid1D = myGrid2D.getSubGrid(j);
 	 *
 	 * This code is deprecated since no final solution was found 
-	 * to solve the prior menioned problem.
+	 * to solve the prior mentioned problem.
 	 * 
 	 * @param j The row-index (y-index, height-index)
 	 * @param subGrid

--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid4D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid4D.java
@@ -175,7 +175,7 @@ public class Grid4D extends NumericGrid {
 		super.setSpacing(spacing);
 		for (Grid3D slice : buffer){
 			if (slice != null)
-				slice.setSpacing(spacing[0],spacing[1]);
+				slice.setSpacing(spacing[0],spacing[1],spacing[2]);
 		}
 	}
 
@@ -184,7 +184,7 @@ public class Grid4D extends NumericGrid {
 		super.setOrigin(origin);
 		for (Grid3D slice : buffer){
 			if (slice != null)
-				slice.setOrigin(origin[0],origin[1]);
+				slice.setOrigin(origin[0],origin[1],origin[2]);
 		}
 	}
 

--- a/src/edu/stanford/rsl/conrad/data/numeric/MultiChannelGrid3D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/MultiChannelGrid3D.java
@@ -27,9 +27,9 @@ public class MultiChannelGrid3D extends Grid3D {
 	}
 	
 	/**
-	 * Returns the Grid2D of the respective Channel
+	 * Returns the Grid3D of the respective Channel
 	 * @param c the channel number
-	 * @return the Grid2D
+	 * @return the Grid3D
 	 */
 	public Grid3D getChannel(int c){
 		Grid3D intermediate = multichannelData.getSubGrid(c);
@@ -117,5 +117,18 @@ public class MultiChannelGrid3D extends Grid3D {
 	 */
 	public int[] getSize() {
 		return new int[]{this.multichannelData.getSize()[0],this.multichannelData.getSize()[1],this.multichannelData.getSize()[2]};
+	}
+	
+	
+	@Override
+	public void setSpacing(double... spacing){
+		super.setSpacing(spacing);
+		multichannelData.setSpacing(spacing[0], spacing[1], spacing[2], 0.0);
+	}
+	
+	@Override
+	public void setOrigin(double... origin){
+		super.setOrigin(origin);
+		multichannelData.setOrigin(origin[0], origin[1], origin[2], 0.0);
 	}
 }


### PR DESCRIPTION
Fixed a typo in Grid2D.
Fixed a bug in Grid4D, where setSpacing/setOrigin was not propagating the 3rd component to sub-grids.
Added setSpacing/setOrigin functionality to MultiChannelGrid3D.