### PR TITLE
Minor changes to NrrdFileReader.

### DIFF
--- a/src/edu/stanford/rsl/conrad/io/NrrdFileReader.java
+++ b/src/edu/stanford/rsl/conrad/io/NrrdFileReader.java
@@ -165,7 +165,7 @@ public class NrrdFileReader extends ImagePlus
 		String thisLine,noteType,noteValue, noteValuelc;
 
 		fi.fileType = FileInfo.GRAY8;  // just assume this for the mo
-		spatialCal.setUnit("micron");  // just assume this for the mo    
+		spatialCal.setUnit("mm");  // just assume this for the mo    
 		fi.fileFormat = FileInfo.RAW;
 		fi.nImages = 1;
 
@@ -328,6 +328,14 @@ public class NrrdFileReader extends ImagePlus
 			
 			if(noteType.equals("space origin")){
 				fi.setSpaceOrigin(parseVector(getSubField(thisLine, 0), fi.dimension));
+				// TOFIX - this order of allocations is not a given!
+				// NB xOrigin are in pixels, whereas space origin is of course
+				// in units; these are converted later
+				if(fi.getSpaceOrigin() != null ) {
+					spatialCal.xOrigin = fi.getSpaceOrigin().getElement(0);
+					spatialCal.yOrigin = fi.getSpaceOrigin().getElement(1);
+					spatialCal.zOrigin = fi.getSpaceOrigin().getElement(2);
+				}
 			}
 			
 			if (noteType.equals("axis mins") || noteType.equals("axismins")) {


### PR DESCRIPTION
Fixed a bug in NrrdFileReader, where the origin was not written to the spatial calibration of the image.
Changed "microns" to "mm" for the moment as this seems to be the more common spacing unit.