### PR TITLE
Fixed invalid assertion in Grid2D copy constructor

### DIFF
--- a/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
+++ b/src/edu/stanford/rsl/conrad/data/numeric/Grid2D.java
@@ -65,7 +65,7 @@ public class Grid2D extends NumericGrid implements Transformable {
 	
 	
 	public Grid2D(Grid2D input){
-		assert input.getWidth()*input.getHeight() == this.buffer.length;
+		// assert input.getWidth()*input.getHeight() == this.buffer.length;
 		this.size = input.size.clone();
 		this.spacing = input.spacing.clone();
 		this.origin = input.origin.clone();


### PR DESCRIPTION
There was an invalid assertion in the Grid2D copy constructor.
Since the member buffer is not initialized at that point, its length is 0 and the assertion will always fail.

JUnit tests will therefore fail without reason if the program code uses this constructor.

The assertion was commented because it does not seem very useful anyway. (Put at a later position it would always pass.)