### PR TITLE
Changes to OpenCL Filtering

### DIFF
--- a/src/edu/stanford/rsl/conrad/filtering/opencl/BilateralFiltering3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/BilateralFiltering3DTool.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Benedikt Lorch, Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import ij.IJ;
@@ -15,7 +19,6 @@ import com.jogamp.opencl.CLMemory;
 
 import edu.stanford.rsl.conrad.data.numeric.Grid3D;
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
-import edu.stanford.rsl.conrad.filtering.opencl.OpenCLFilteringTool3D.kernelname;
 import edu.stanford.rsl.conrad.utils.FileUtil;
 import edu.stanford.rsl.conrad.utils.ImageUtil;
 import edu.stanford.rsl.conrad.utils.UserUtil;
@@ -348,7 +351,7 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 
 	@Override
 	public String getToolName() {
-		return "OpenCL Bilateral Filter 3-D";
+		return "OpenCL Bilateral Filter 3D";
 	}
 
 
@@ -371,3 +374,8 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 	}
 
 }
+
+/*
+ * Copyright (C) 2018 Benedikt Lorch, Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/BilateralFiltering3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/BilateralFiltering3DTool.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import ij.IJ;
@@ -18,6 +15,7 @@ import com.jogamp.opencl.CLMemory;
 
 import edu.stanford.rsl.conrad.data.numeric.Grid3D;
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.filtering.opencl.OpenCLFilteringTool3D.kernelname;
 import edu.stanford.rsl.conrad.utils.FileUtil;
 import edu.stanford.rsl.conrad.utils.ImageUtil;
 import edu.stanford.rsl.conrad.utils.UserUtil;
@@ -30,7 +28,6 @@ import edu.stanford.rsl.conrad.utils.UserUtil;
  */
 public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 	
-
 	private static final long serialVersionUID = 8268932618986579399L;
 	protected double sigmaPhoto = 1;
 	protected double[] sigmaGeom = { 5.d, 5.d, 5.d };
@@ -45,64 +42,14 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 	protected CLBuffer<FloatBuffer> template;
 	
 	
-	// Accessors and mutators for configuration variables
-	public void setSigmaPhoto(double sigmaPhoto) {
-		this.sigmaPhoto = sigmaPhoto;
+	public BilateralFiltering3DTool() {
+		this.kernelName = kernelname.BILATERAL_FILTER_3D;
 	}
-	
-	public void setSigmaGeom(double[] sigmaGeom) {
-		this.sigmaGeom = sigmaGeom;
-	}
-	
-	public void setKernelWidth() {
-		
-		assert(this.sigmaGeom.length == 3);
-		assert(this.sigmaGeom[0] != 0.d);
-		assert(this.sigmaGeom[1] != 0.d);
-		assert(this.sigmaGeom[2] != 0.d);
-		assert(this.sigmaPhoto != 0.d);
-		
-		this.kernelWidth = computeKernelWidth();
-	}
-	
-	public void setKernelWidth(int kernelWidth) {
-		this.kernelWidth = kernelWidth;
-	}
-	
-	public double getSigmaPhoto() {
-		return this.sigmaPhoto;
-	}
-	
-	public double[] getSigmaGeom() {
-		return this.sigmaGeom;
-	}
-	
-	
-	public void setConfigured(boolean configured) {
-		this.configured = configured;
-	}
-	
-	
-	/**
-	 * Configure whether to ask for a guidance image
-	 * @param askForGuidance
-	 */
-	public void setAskForGuidance(boolean askForGuidance) {
-		this.askForGuidance = askForGuidance;
-	}
-	
-	
-	/**
-	 * Gets the kernel width
-	 * @return kernelWidth
-	 */
-	public int getKernelWidth() {
-		return kernelWidth;
-	}
-	
 	
 	@Override
 	public void configure() throws Exception {
+		
+		this.kernelName = kernelname.BILATERAL_FILTER_3D;
 		
 		double[] sGeom = UserUtil.queryArray("Enter geometric sigma (for each dimension)", sigmaGeom);
 		if (sGeom.length == 3) {
@@ -143,6 +90,113 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 		
 		configured = true;
 
+	}
+	
+	/**
+	 * Called by process() before the processing begins. Put your write buffers to the queue here.
+	 * @param input Grid 3-D to be processed
+	 * @param queue CommandQueue for the specific device
+	 */
+	@SuppressWarnings("unused")
+	@Override
+	protected void prepareProcessing(Grid3D input, CLCommandQueue queue) {
+		
+		// Check for errors with guidance grid
+		if (showGuidance) {
+			if (null == guidanceGrid) {
+				throw new IllegalArgumentException("The user claimed to add a guidance image but the guidance image could not be found.");
+			}
+			else {
+				// Assure equal dimensions
+				int[] guidanceSize = guidanceGrid.getSize();
+				if (width != guidanceSize[0]
+						|| height != guidanceSize[1]
+						|| depth != guidanceSize[2]) {
+					throw new IllegalArgumentException("The given guidence image's dimensions are not equal to the sizes which this filter has been configured for.");
+				}
+			}
+		}
+		else if (null != guidanceGrid) {
+			// Guidance image given but not used
+			String message = "You passed a template image to process() but claimed not to use a guidance image. Your template image will be ignored. In order to use the template image with Joint Bilateral Filter, click 'yes' when prompted whether to use a guidance image.";
+			if (debug > 0) {
+				System.err.println(message);
+			}
+		}
+		
+		// Copy image data into linear floatBuffer
+		gridToBuffer(image.getBuffer(), input);
+		image.getBuffer().rewind();
+		queue.putWriteBuffer(image, true);
+		
+		// Copy guidance image
+		if (showGuidance && null != guidanceGrid) {
+			template = clContext.createFloatBuffer(this.width * this.height * this.depth, CLMemory.Mem.READ_ONLY);
+			gridToBuffer(template.getBuffer(), guidanceGrid);
+			template.getBuffer().rewind();
+			queue.putWriteBuffer(template, true);
+		}
+		
+		// Compute geometric kernel: If the kernel is a sphere, then use symmetric properties to speed up processing
+		Grid3D geometricKernelGrid = (sigmaGeom[0] == sigmaGeom[1] && sigmaGeom[1] == sigmaGeom[2]) ? computeSymmetricGeometricKernel() : computeGeometricKernel();
+		geometricKernel = clContext.createFloatBuffer(kernelWidth * kernelWidth * kernelWidth, CLMemory.Mem.READ_ONLY);
+		gridToBuffer(geometricKernel.getBuffer(), geometricKernelGrid);
+		geometricKernel.getBuffer().rewind();
+		queue.putWriteBuffer(geometricKernel, true);
+	}
+	
+	// Accessors and mutators for configuration variables
+	public void setSigmaPhoto(double sigmaPhoto) {
+		this.sigmaPhoto = sigmaPhoto;
+	}
+	
+	public void setSigmaGeom(double[] sigmaGeom) {
+		this.sigmaGeom = sigmaGeom;
+	}
+	
+	public void setKernelWidth() {
+		
+		assert(this.sigmaGeom.length == 3);
+		assert(this.sigmaGeom[0] != 0.d);
+		assert(this.sigmaGeom[1] != 0.d);
+		assert(this.sigmaGeom[2] != 0.d);
+		assert(this.sigmaPhoto != 0.d);
+		
+		this.kernelWidth = computeKernelWidth();
+	}
+	
+	public void setKernelWidth(int kernelWidth) {
+		this.kernelWidth = kernelWidth;
+	}
+	
+	public double getSigmaPhoto() {
+		return this.sigmaPhoto;
+	}
+	
+	public double[] getSigmaGeom() {
+		return this.sigmaGeom;
+	}
+	
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+	
+	
+	/**
+	 * Configure whether to ask for a guidance image
+	 * @param askForGuidance
+	 */
+	public void setAskForGuidance(boolean askForGuidance) {
+		this.askForGuidance = askForGuidance;
+	}
+	
+	
+	/**
+	 * Gets the kernel width
+	 * @return kernelWidth
+	 */
+	public int getKernelWidth() {
+		return kernelWidth;
 	}
 	
 	
@@ -230,9 +284,6 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 		
 		return geometricKernel;
 	}
-	
-	
-	
 
 	@Override
 	protected void configureKernel() {
@@ -257,60 +308,7 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 		}
 	}
 	
-	
-	/**
-	 * Called by process() before the processing begins. Put your write buffers to the queue here.
-	 * @param input Grid 3-D to be processed
-	 * @param queue CommandQueue for the specific device
-	 */
-	@Override
-	protected void prepareProcessing(Grid3D input, CLCommandQueue queue) {
-		
-		// Check for errors with guidance grid
-		if (showGuidance) {
-			if (null == guidanceGrid) {
-				throw new IllegalArgumentException("The user claimed to add a guidance image but the guidance image could not be found.");
-			}
-			else {
-				// Assure equal dimensions
-				int[] guidanceSize = guidanceGrid.getSize();
-				if (width != guidanceSize[0]
-						|| height != guidanceSize[1]
-						|| depth != guidanceSize[2]) {
-					throw new IllegalArgumentException("The given guidence image's dimensions are not equal to the sizes which this filter has been configured for.");
-				}
-			}
-		}
-		else if (null != guidanceGrid) {
-			// Guidance image given but not used
-			String message = "You passed a template image to process() but claimed not to use a guidance image. Your template image will be ignored. In order to use the template image with Joint Bilateral Filter, click 'yes' when prompted whether to use a guidance image.";
-			if (debug > 0) {
-				System.err.println(message);
-			}
-		}
-		
-		// Copy image data into linear floatBuffer
-		gridToBuffer(image.getBuffer(), input);
-		image.getBuffer().rewind();
-		queue.putWriteBuffer(image, true);
-		
-		// Copy guidance image
-		if (showGuidance && null != guidanceGrid) {
-			template = clContext.createFloatBuffer(this.width * this.height * this.depth, CLMemory.Mem.READ_ONLY);
-			gridToBuffer(template.getBuffer(), guidanceGrid);
-			template.getBuffer().rewind();
-			queue.putWriteBuffer(template, true);
-		}
-		
-		// Compute geometric kernel: If the kernel is a sphere, then use symmetric properties to speed up processing
-		Grid3D geometricKernelGrid = (sigmaGeom[0] == sigmaGeom[1] && sigmaGeom[1] == sigmaGeom[2]) ? computeSymmetricGeometricKernel() : computeGeometricKernel();
-		geometricKernel = clContext.createFloatBuffer(kernelWidth * kernelWidth * kernelWidth, CLMemory.Mem.READ_ONLY);
-		gridToBuffer(geometricKernel.getBuffer(), geometricKernelGrid);
-		geometricKernel.getBuffer().rewind();
-		queue.putWriteBuffer(geometricKernel, true);
-	}
-	
-	
+
 	
 	@Override
 	public void cleanup() {
@@ -320,8 +318,6 @@ public class BilateralFiltering3DTool extends OpenCLFilteringTool3D {
 		super.cleanup();
 	}
 	
-	
-
 	@Override
 	public String getBibtexCitation() {
 		String bibtex = "@inproceedings{Tomasi98-BFF,\n" +

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/Binarization2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/Binarization2DTool.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
@@ -86,3 +90,8 @@ public class Binarization2DTool extends OpenCLFilteringTool2D {
 	}
 	
 }
+
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/Binarization2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/Binarization2DTool.java
@@ -1,0 +1,88 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.utils.UserUtil;
+
+/**
+ * Tool for OpenCL binarization of a Grid 2D.
+ * This tool uses the CONRAD internal Grid 2-D data structure.
+ * 
+ * @author Jennifer Maier
+ *
+ */
+public class Binarization2DTool extends OpenCLFilteringTool2D {
+
+	private static final long serialVersionUID = 5508773057260674367L;
+	private double thres = 0.5;
+	
+	public Binarization2DTool() {
+		this.kernelName = kernelname.BINARIZATION_2D;
+	}
+	
+	@Override
+	public void configure() throws Exception {		
+
+		this.thres = (float) UserUtil.queryDouble("Enter threshold for binarization", thres);
+		configured = true;
+
+	}
+	
+	// Getter and Setter
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+	
+	public double getThres() {
+		return thres;
+	}
+
+	public void setThres(double thres) {
+		this.thres = thres;
+	}
+	
+	@Override
+	protected void configureKernel() {
+		filterKernel = program.createCLKernel("binarization2D");
+
+		filterKernel.setForce32BitArgs(true);
+		
+		filterKernel
+		.putArg(image)
+		.putArg(result)
+		.putArg(width)
+		.putArg(height)
+		.putArg(thres);	
+
+	}
+
+	@Override
+	public String getBibtexCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getMedlineCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isDeviceDependent() {
+		return true;
+	}
+
+	@Override
+	public String getToolName() {
+		return "OpenCL Binarization 2D";
+	}
+
+	@Override
+	public ImageFilteringTool clone() {
+		Binarization2DTool clone = new Binarization2DTool();
+		clone.setThres(this.getThres());
+		clone.setConfigured(this.configured);
+		return clone;
+	}
+	
+}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/Kernel3x3Filtering2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/Kernel3x3Filtering2DTool.java
@@ -1,0 +1,146 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import java.nio.FloatBuffer;
+
+import com.jogamp.opencl.CLBuffer;
+import com.jogamp.opencl.CLCommandQueue;
+import com.jogamp.opencl.CLMemory;
+
+import edu.stanford.rsl.conrad.data.numeric.Grid2D;
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.utils.UserUtil;
+
+/**
+ * Tool for OpenCL Filtering of a Grid 2D with an arbitrary 3x3 Filter Kernel.
+ * The values in the kernel should sum up to 1.
+ * This tool uses the CONRAD internal Grid 2-D data structure.
+ * 
+ * @author Jennifer Maier
+ *
+ */
+public class Kernel3x3Filtering2DTool extends OpenCLFilteringTool2D {
+
+	private static final long serialVersionUID = -3381321981652625848L;
+	protected double[] kernel = {0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0};
+	private static final int KERNEL_WIDTH = 3;
+	protected CLBuffer<FloatBuffer> kernelBuffer;
+	
+	public Kernel3x3Filtering2DTool() {
+		this.kernelName = kernelname.KERNEL3x3_FILTER_2D;
+	}
+	
+	@Override
+	public void configure() throws Exception {		
+
+		kernel = UserUtil.queryArray("Enter 3x3 kernel as one line", kernel);
+		if (kernel.length != KERNEL_WIDTH*KERNEL_WIDTH) {
+			throw new IllegalArgumentException("Kernel's length needs to be 9.");
+		}
+
+		configured = true;
+
+	}
+	
+	/**
+	 * Called by process() before the processing begins. Put your write buffers to the queue here.
+	 * @param input Grid 3-D to be processed
+	 * @param queue CommandQueue for the specific device
+	 */
+	@Override
+	protected void prepareProcessing(Grid2D input, CLCommandQueue queue) {
+		
+		// Copy image data into linear floatBuffer
+		gridToBuffer(image.getBuffer(), input);
+		image.getBuffer().rewind();
+		queue.putWriteBuffer(image, true);
+		
+		// prepare kernel and buffer
+		float[] kernelFloat = {(float) kernel[0], (float) kernel[1], (float) kernel[2], (float) kernel[3],
+				(float) kernel[4], (float) kernel[5], (float) kernel[6], (float) kernel[7], (float) kernel[8]};
+		Grid2D kernelGrid = new Grid2D(kernelFloat, KERNEL_WIDTH, KERNEL_WIDTH);
+		kernelBuffer = clContext.createFloatBuffer(KERNEL_WIDTH * KERNEL_WIDTH, CLMemory.Mem.READ_ONLY);
+		gridToBuffer(kernelBuffer.getBuffer(), kernelGrid);
+		kernelBuffer.getBuffer().rewind();
+		queue.putWriteBuffer(kernelBuffer, true);
+	}
+	
+	// Getter and Setter
+
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+	
+	public double[] getKernel() {
+		return kernel;
+	}
+
+	public void setKernel(double[] kernel) {
+		// check whether it is a 3x3 Kernel
+		if (kernel.length != KERNEL_WIDTH*KERNEL_WIDTH) {
+			throw new IllegalArgumentException("Kernel's length needs to be 9.");
+		}
+		this.kernel = kernel;
+	}
+	
+	public void setKernel(double[][] kernel) {
+		// check whether it is a 3x3 Kernel
+		if (kernel.length * kernel[0].length != KERNEL_WIDTH*KERNEL_WIDTH) {
+			throw new IllegalArgumentException("Kernel's length needs to be 9.");
+		}
+		
+		// restructure double[][] to double[]
+		double[] kernelArray = new double[KERNEL_WIDTH * KERNEL_WIDTH];
+		for (int i = 0; i < kernel.length; i++) {
+			for (int j = 0; j < kernel[0].length; j++) {
+				kernelArray[i * kernel.length + j] = kernel[i][j];
+			}
+		}
+		
+		this.kernel = kernelArray;
+	}
+	
+	@Override
+	protected void configureKernel() {
+		filterKernel = program.createCLKernel("kernel3x3Filter2D");
+
+		filterKernel
+		.putArg(image)
+		.putArg(result)
+		.putArg(width)
+		.putArg(height)
+		.putArg(KERNEL_WIDTH)
+		.putArg(kernelBuffer);	
+
+	}
+
+	@Override
+	public String getBibtexCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getMedlineCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isDeviceDependent() {
+		return true;
+	}
+
+	@Override
+	public String getToolName() {
+		return "OpenCL Filter 3x3 Kernel  2D";
+	}
+
+	@Override
+	public ImageFilteringTool clone() {
+		Kernel3x3Filtering2DTool clone = new Kernel3x3Filtering2DTool();
+		clone.setKernel(this.getKernel().clone());
+		clone.setConfigured(this.configured);
+		return clone;
+	}
+	
+}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/Kernel3x3Filtering2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/Kernel3x3Filtering2DTool.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import java.nio.FloatBuffer;
@@ -144,3 +148,8 @@ public class Kernel3x3Filtering2DTool extends OpenCLFilteringTool2D {
 	}
 	
 }
+
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DTool.java
@@ -1,0 +1,114 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.utils.UserUtil;
+
+/**
+ * Tool for OpenCL 2D Mean Filtering a Grid 2D.
+ * This tool uses the CONRAD internal Grid 2-D data structure.
+ *   
+ * @author Jennifer Maier
+ *
+ */
+public class MeanFiltering2DTool extends OpenCLFilteringTool2D {
+
+	private static final long serialVersionUID = -3381321981652625848L;
+	protected int kernelWidth = 3;
+	protected int kernelHeight = 3;
+	
+	public MeanFiltering2DTool() {
+		this.kernelName = kernelname.MEAN_FILTER_2D;
+	}
+
+	@Override
+	public void configure() throws Exception {		
+
+		kernelWidth = UserUtil.queryInt("Enter kernel width\n(even numbers will be incremented by 1)", kernelWidth);
+		if (kernelWidth % 2 == 0) {
+			kernelWidth++;
+		}
+
+		kernelHeight = UserUtil.queryInt("Enter kernel width\n(even numbers will be incremented by 1)", kernelHeight);
+		if (kernelHeight % 2 == 0) {
+			kernelHeight++;
+		}
+
+		configured = true;
+
+	}
+	
+	// Getter and Setter
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+	
+	public int getKernelWidth() {
+		return kernelWidth;
+	}
+
+	public void setKernelWidth(int kernelWidth) {
+		if (kernelWidth % 2 == 0) {
+			kernelWidth++;
+		}
+		this.kernelWidth = kernelWidth;
+	}
+
+	public int getKernelHeight() {
+		return kernelHeight;
+	}
+
+	public void setKernelHeight(int kernelHeight) {
+		if (kernelHeight % 2 == 0) {
+			kernelHeight++;
+		}
+		this.kernelHeight = kernelHeight;
+	}
+
+	@Override
+	protected void configureKernel() {
+		filterKernel = program.createCLKernel("meanFilter2D");
+
+		filterKernel
+		.putArg(image)
+		.putArg(result)
+		.putArg(width)
+		.putArg(height)
+		.putArg(kernelWidth)
+		.putArg(kernelHeight)
+		.putArg(1.0f/(kernelWidth*kernelHeight));			
+
+	}
+	
+	@Override
+	public String getBibtexCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getMedlineCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isDeviceDependent() {
+		return true;
+	}
+
+	@Override
+	public String getToolName() {
+		return "OpenCL Mean Filter 2D";
+	}
+
+	@Override
+	public ImageFilteringTool clone() {
+		MeanFiltering2DTool clone = new MeanFiltering2DTool();
+		clone.setKernelHeight(this.getKernelHeight());
+		clone.setKernelWidth(this.getKernelWidth());
+		clone.setConfigured(this.configured);
+
+		return clone;
+	}
+	
+}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DTool.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
@@ -112,3 +116,8 @@ public class MeanFiltering2DTool extends OpenCLFilteringTool2D {
 	}
 	
 }
+
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DinGrid3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DinGrid3DTool.java
@@ -1,0 +1,120 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import com.jogamp.opencl.CLCommandQueue;
+
+import edu.stanford.rsl.conrad.data.numeric.Grid3D;
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.filtering.opencl.OpenCLFilteringTool3D;
+import edu.stanford.rsl.conrad.utils.UserUtil;
+
+/**
+ * Tool for OpenCL computation of the 2D Mean Filter in each slice of a Grid 3D.
+ * This tool uses the CONRAD internal Grid 3-D and Grid 2-D data structure.
+ *   
+ * @author Jennifer Maier
+ *
+ */
+
+public class MeanFiltering2DinGrid3DTool extends OpenCLFilteringTool3D {
+
+	private static final long serialVersionUID = -1469783337390366468L;
+	protected int kernelWidth = 3;
+	protected int kernelHeight = 3;
+
+	public MeanFiltering2DinGrid3DTool() {
+		this.kernelName = kernelname.MEAN_FILTER_2D_IN_GRID3D;
+	}
+
+	@Override
+	public void configure() throws Exception {		
+
+		kernelWidth = UserUtil.queryInt("Enter kernel width\n(even numbers will be incremented by 1)", kernelWidth);
+		if (kernelWidth % 2 == 0) {
+			kernelWidth++;
+		}
+
+		kernelHeight = UserUtil.queryInt("Enter kernel width\n(even numbers will be incremented by 1)", kernelHeight);
+		if (kernelHeight % 2 == 0) {
+			kernelHeight++;
+		}
+
+		configured = true;
+
+	}
+	
+	// Getter and Setter
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+
+	public int getKernelWidth() {
+		return kernelWidth;
+	}
+
+	public void setKernelWidth(int kernelWidth) {
+		if (kernelWidth % 2 == 0) {
+			kernelWidth++;
+		}
+		this.kernelWidth = kernelWidth;
+	}
+
+	public int getKernelHeight() {
+		return kernelHeight;
+	}
+
+	public void setKernelHeight(int kernelHeight) {
+		if (kernelHeight % 2 == 0) {
+			kernelHeight++;
+		}
+		this.kernelHeight = kernelHeight;
+	}		
+
+	@Override
+	protected void configureKernel() {
+		filterKernel = program.createCLKernel("meanFilter2DinGrid3D");
+
+		filterKernel
+		.putArg(image)
+		.putArg(result)
+		.putArg(width)
+		.putArg(height)
+		.putArg(depth)
+		.putArg(kernelWidth)
+		.putArg(kernelHeight)
+		.putArg(1.0f/(kernelWidth*kernelHeight));			
+
+	}
+	
+	@Override
+	public String getBibtexCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getMedlineCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isDeviceDependent() {
+		return true;
+	}
+
+	@Override
+	public String getToolName() {
+		return "OpenCL Mean Filter 2D slices in Grid3D";
+	}
+
+	@Override
+	public ImageFilteringTool clone() {
+		MeanFiltering2DinGrid3DTool clone = new MeanFiltering2DinGrid3DTool();
+		clone.setKernelHeight(this.getKernelHeight());
+		clone.setKernelWidth(this.getKernelWidth());
+		clone.setConfigured(this.configured);
+
+		return clone;
+	}
+
+}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DinGrid3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering2DinGrid3DTool.java
@@ -1,8 +1,9 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
-import com.jogamp.opencl.CLCommandQueue;
-
-import edu.stanford.rsl.conrad.data.numeric.Grid3D;
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
 import edu.stanford.rsl.conrad.filtering.opencl.OpenCLFilteringTool3D;
 import edu.stanford.rsl.conrad.utils.UserUtil;
@@ -104,7 +105,7 @@ public class MeanFiltering2DinGrid3DTool extends OpenCLFilteringTool3D {
 
 	@Override
 	public String getToolName() {
-		return "OpenCL Mean Filter 2D slices in Grid3D";
+		return "OpenCL Mean Filter 3D (slice-wise)";
 	}
 
 	@Override
@@ -118,3 +119,8 @@ public class MeanFiltering2DinGrid3DTool extends OpenCLFilteringTool3D {
 	}
 
 }
+
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering3DTool.java
@@ -1,0 +1,139 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import java.nio.FloatBuffer;
+
+import com.jogamp.opencl.CLBuffer;
+import com.jogamp.opencl.CLCommandQueue;
+import com.jogamp.opencl.CLMemory;
+
+import edu.stanford.rsl.conrad.data.numeric.Grid3D;
+import edu.stanford.rsl.conrad.data.numeric.NumericPointwiseOperators;
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+
+/**
+ * Tool for OpenCL computation of the Mean Filter in a Grid 3D using the 6-connected neighborhood of each voxel.
+ * This tool uses the CONRAD internal Grid 3-D data structure.
+ * 
+ * If desired, not all voxels in the input Grid3D are processed. Then, a Grid3D of the same size as the processed image
+ * has to be handed to the tool using the Setter for computeValueGrid. This computeValueGrid contains zeros for all
+ * voxels that should NOT be processed. If no computeValueGrid is handed to the tool, all voxels are processed. 
+ *  
+ * @author Jennifer Maier
+ *
+ */
+
+public class MeanFiltering3DTool extends OpenCLFilteringTool3D {
+	
+	private static final long serialVersionUID = -1469783337390366468L;
+	protected CLBuffer<FloatBuffer> computeValue;
+	private Grid3D computeValueGrid;
+
+	public MeanFiltering3DTool() {
+		this.kernelName = kernelname.MEAN_FILTER_3D;
+	}
+
+	@Override
+	public void configure() throws Exception {		
+		
+		this.kernelName = kernelname.MEAN_FILTER_3D;
+				
+		// if the opneCL structures are initialized and the computeValueGrid is set, we can already create the openCL
+		// computeValue Buffer
+		if (init && computeValueGrid != null) {
+			computeValue = clContext.createFloatBuffer(width * height * depth, CLMemory.Mem.READ_ONLY);
+			gridToBuffer(computeValue.getBuffer(), computeValueGrid);
+			computeValue.getBuffer().rewind();
+		}
+
+		configured = true;
+		
+	}
+	
+	/**
+	 * Called by process() before the processing begins. Put your write buffers to the queue here.
+	 * @param input Grid 3-D to be processed
+	 * @param queue CommandQueue for the specific device
+	 */
+	@Override
+	protected void prepareProcessing(Grid3D input, CLCommandQueue queue) {
+				
+		// Copy image data into linear floatBuffer
+		gridToBuffer(image.getBuffer(), input);
+		image.getBuffer().rewind();
+		queue.putWriteBuffer(image, true);		
+		
+		// initialize openCL computeValue Buffer, if this hasn't been done before and put it in queue
+		if (computeValue == null) {
+			// if no computeValueGrid was set, all voxels should be processed
+			// -> Grid3D of same size as input containing only non-zero values
+			if (computeValueGrid == null) {
+				computeValueGrid = new Grid3D(width, height, depth);
+				NumericPointwiseOperators.fill(computeValueGrid, 1.0f);
+			}
+			computeValue = clContext.createFloatBuffer(width * height * depth, CLMemory.Mem.READ_ONLY);
+			gridToBuffer(computeValue.getBuffer(), computeValueGrid);
+			computeValue.getBuffer().rewind();
+		}
+		queue.putWriteBuffer(computeValue, true);
+		
+	}
+	
+	// Getter and Setter
+	public void setConfigured(boolean configured) {
+		this.configured = configured;
+	}
+	
+	public void setComputeValueGrid (Grid3D computeValueGrid) {
+		this.computeValueGrid = computeValueGrid;
+	}
+
+	public Grid3D getComputeValueGrid () {
+		return this.computeValueGrid;
+	}
+	
+	@Override
+	protected void configureKernel() {
+		filterKernel = program.createCLKernel("meanFilter6Surrounding3D");
+		
+		filterKernel
+		.putArg(image)
+		.putArg(result)
+		.putArg(computeValue)
+		.putArg(width)
+		.putArg(height)
+		.putArg(depth);
+		
+	}
+	
+	@Override
+	public String getBibtexCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getMedlineCitation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isDeviceDependent() {
+		return true;
+	}
+
+	@Override
+	public String getToolName() {
+		return "OpenCL Mean Filter 3D (6-connected)";
+	}
+
+	@Override
+	public ImageFilteringTool clone() {
+		MeanFiltering3DTool clone = new MeanFiltering3DTool();
+		clone.setComputeValueGrid((Grid3D) this.computeValueGrid.clone());
+		clone.setConfigured(this.configured);
+
+		return clone;
+	}
+
+}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering3DTool.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/MeanFiltering3DTool.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import java.nio.FloatBuffer;
@@ -137,3 +141,8 @@ public class MeanFiltering3DTool extends OpenCLFilteringTool3D {
 	}
 
 }
+
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool2D.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool2D.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import java.io.IOException;
@@ -290,3 +294,7 @@ import edu.stanford.rsl.conrad.utils.UserUtil;
 		}
 		
 	}
+	/*
+	 * Copyright (C) 2018 Jennifer Maier
+	 * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+	*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool2D.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool2D.java
@@ -1,0 +1,292 @@
+package edu.stanford.rsl.conrad.filtering.opencl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.EnumSet;
+
+import com.jogamp.opencl.CLBuffer;
+import com.jogamp.opencl.CLCommandQueue;
+import com.jogamp.opencl.CLContext;
+import com.jogamp.opencl.CLDevice;
+import com.jogamp.opencl.CLKernel;
+import com.jogamp.opencl.CLMemory;
+import com.jogamp.opencl.CLProgram;
+
+import edu.stanford.rsl.conrad.data.numeric.Grid2D;
+import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
+import edu.stanford.rsl.conrad.opencl.OpenCLUtil;
+import edu.stanford.rsl.conrad.utils.UserUtil;
+
+
+	/**
+	 * This is an abstract template for a filtering tool based on OpenCL. It already implements basic procedures,
+	 * which can be overwritten by subclasses.  
+	 * @author Benedikt Lorch, Jennifer Maier
+	 *
+	 */
+	public abstract class OpenCLFilteringTool2D extends ImageFilteringTool {
+
+		private static final long serialVersionUID = -2903946802060212554L;		
+
+		protected final int debug = 0;
+		
+		// initialized in init method.
+		protected CLContext clContext;
+		protected CLDevice device;
+		protected CLKernel filterKernel;
+		protected CLProgram program;
+		protected boolean init = false;
+		protected CLBuffer<FloatBuffer> image;
+		protected CLBuffer<FloatBuffer> result;
+		protected int width;
+		protected int height;
+		protected kernelname kernelName;
+		
+		public enum kernelname{
+			KERNEL3x3_FILTER_2D("kernel3x3Filter2D.cl"),
+			MEAN_FILTER_2D("meanFilter2D.cl"),
+			BINARIZATION_2D("binarization2D.cl");
+			
+			private String filename;
+			
+			private kernelname(String fn){
+				this.filename = fn;
+			}
+			public String getName(){
+				return this.filename;
+			}
+		}
+		
+		
+		/**
+		 * Initializes input and output buffer, clContext, dimensions and builds the OpenCL program
+		 * @param width of the grids to process
+		 * @param height of the grids to process
+		 */
+		@SuppressWarnings("unused")
+		public void init(int width, int height) {
+			if (!init) {
+				// Get dimensions from given grid
+				this.width = width;
+				this.height = height;
+				
+				// Create OpenCL context and device if not done so yet
+				getDevice();
+				
+				// Allocate memory
+				image = clContext.createFloatBuffer(width * height, CLMemory.Mem.READ_ONLY);
+				result = clContext.createFloatBuffer(width * height, CLMemory.Mem.WRITE_ONLY);
+				
+				// Build OpenCL program and create kernel
+				try {
+					InputStream input = OpenCLFilteringTool2D.class.getResourceAsStream(kernelName.filename);
+					if (null == input) {
+						throw new IOException("InputStream input is null." + kernelName.filename + " could not be loaded");
+					}
+					
+					program = clContext.createProgram(input);
+					program.build();
+				} catch (IOException e) {
+					throw new RuntimeException("The kernel file " + kernelName.filename + " could not be loaded.", e);
+				}
+				
+				if (debug > 0) {
+					System.out.println(program.getBuildStatus(device));
+					System.out.println(program.getBuildLog());
+				}
+				
+				init = true;
+			}
+		}
+		
+		/**
+		 * Returns the device to be used. In case context or device have not been initalized yet, they will be created 
+		 * @return device to be used
+		 */
+		public CLDevice getDevice() {
+			if (null == device) {
+				if (null == clContext) {
+					clContext = OpenCLUtil.createContext();
+					OpenCLUtil.initFilter(clContext);
+				}
+				device = clContext.getMaxFlopsDevice();
+			}
+			return device;
+		}
+
+		
+		/**
+		 * Configures the filter kernel
+		 * Must set filterKernel = program.createCLKernel({kernelName})
+		 * Must do filterKernel.putArg(..) in order of kernel's parameters
+		 */
+		protected abstract void configureKernel();
+		
+		
+		/**
+		 * Called by process() before the processing begins. Put your write buffers to the queue here.
+		 * @param input Grid 2-D to be processed
+		 * @param queue CommandQueue for the specific device
+		 */
+		protected void prepareProcessing(Grid2D input, CLCommandQueue queue) {
+			// Copy image data into linear floatBuffer
+			gridToBuffer(image.getBuffer(), input);
+			image.getBuffer().rewind();
+			queue.putWriteBuffer(image, true);
+		}
+		
+		
+		/**
+		 * Called by process() after the processing. Put your read buffers to the queue here.
+		 * @param queue CommandQueue for the specific device
+		 * @return result as Grid 2-D
+		 */
+		@SuppressWarnings("unused")
+		protected Grid2D completeProcessing(CLCommandQueue queue) {
+			// Read back result with blocking call
+			queue.putReadBuffer(result, true);
+			
+			if (debug > 0) {
+				System.out.println("Retrieved the result buffer back from the GPU");
+			}
+			
+			// Copy the result from the buffer back into a Grid2D
+			FloatBuffer resultBuffer = result.getBuffer();
+			resultBuffer.rewind();
+			Grid2D result = bufferToGrid(resultBuffer, width, height);		
+			resultBuffer.rewind();
+			
+			if (debug > 0) {
+				System.out.println("Transformed the result buffer back to a Grid 2-D");
+			}
+			return result;
+		}
+		
+		
+		/**
+		 * Applies the kernel to the given grid
+		 * @param grid 2-D image to filter
+		 * @return the filtered 2-D image
+		 */
+		@SuppressWarnings("unused")
+		public Grid2D process(Grid2D grid) {
+			try {
+				int size[] = grid.getSize();
+				// If not initialized yet, it's getting time
+				if (!init) {
+					if (this.kernelName == null) { // shouldn't happen
+						ArrayList<kernelname> availableKernelsList = new ArrayList<kernelname>(EnumSet.allOf(kernelname.class));
+						kernelname[] availableKernelsArray = availableKernelsList.toArray(new kernelname[availableKernelsList.size()]);
+						this.kernelName = (kernelname) UserUtil.chooseObject("Please select the 3D openCL filter you would like to apply", "Choose Filter", availableKernelsArray, kernelname.BINARIZATION_2D);
+					}
+					init(size[0], size[1]);
+				}				
+				
+				// Make sure that dimensions do match
+				if (width != size[0] || height != size[1]) {
+					throw new IllegalArgumentException("The given grid's dimensions are not equal to the sizes which this filter has been configured for.");
+				}
+				
+				CLCommandQueue queue = device.createCommandQueue();
+				
+				// Copy image data into linear floatBuffer
+				prepareProcessing(grid, queue);
+		
+				// Create filter kernel and put args
+				configureKernel();
+				
+				// GPU dependent constraints:
+				// localWorkSizeX * localWorkSizeY * localWorkSizeZ <= kernel.getWorkGroupSize(device)
+				// Each individual dimension <= device.getMaxWorkItemSizes()
+				long workGroupSize = filterKernel.getWorkGroupSize(device);
+				
+				// Cube root will usually not result in integer
+				int groupSize = (int) Math.ceil(Math.pow(workGroupSize, 1.0/2));
+				groupSize = (groupSize * groupSize > workGroupSize) ? groupSize - 1 : groupSize;
+				
+				if (debug > 0) {
+					System.out.println("Starting processing on GPU");
+				}
+				
+				// Enqueue the filter kernel
+				queue.put2DRangeKernel(filterKernel, 0, 0, OpenCLUtil.roundUp(groupSize, width), OpenCLUtil.roundUp(groupSize, height), groupSize, groupSize);
+				queue.flush();
+				queue.finish();
+				
+				if (debug > 0) {
+					System.out.println("Finished processing on GPU");
+				}
+				
+				Grid2D result = completeProcessing(queue);
+				
+				queue.release();
+				return result;
+			
+			} catch (Exception e) {
+				
+				e.printStackTrace();
+			}
+			return null;
+		}
+		
+		/**
+		 * Copies the float data of a given grid into a linear float buffer
+		 * @param imageBuffer: destination buffer
+		 * @param grid: input 2-D grid
+		 * @return linear float buffer
+		 */
+		protected FloatBuffer gridToBuffer(FloatBuffer imageBuffer, Grid2D grid) {
+			imageBuffer.rewind();
+			float[] planeBuffer = grid.getBuffer();
+			imageBuffer.put(planeBuffer);
+
+			return imageBuffer;
+		}
+		
+		
+		/**
+		 * Copies the float buffer as linear memory into a Grid 2-D
+		 * @param FloatBuffer buffer as linear memory
+		 * @param width of the 2-D grid to be returned
+		 * @param height of the 2-D grid to be returned
+		 * @return Grid2D
+		 */
+		protected Grid2D bufferToGrid(FloatBuffer buffer, int width, int height) {
+
+			buffer.rewind();	
+			float[] plane = new float[width * height];	
+			buffer.get(plane);
+			Grid2D grid = new Grid2D(plane, width, height);
+
+			return grid;
+		}
+		
+		public void setKernelName(kernelname kernelName) {
+			this.kernelName = kernelName;
+		}
+		
+		public kernelname getKernelName() {
+			return this.kernelName;
+		}
+
+		@Override
+		public void prepareForSerialization() {
+			init = false;
+		}
+		
+		
+		public void cleanup(){
+			release();
+		}
+
+		
+		protected void release(){
+			image.release();
+			result.release();
+			filterKernel.release();
+			OpenCLUtil.releaseContext(clContext);
+		}
+		
+	}

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool3D.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool3D.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
+import java.util.EnumSet;
 
 import com.jogamp.opencl.CLBuffer;
 import com.jogamp.opencl.CLCommandQueue;
@@ -17,18 +18,21 @@ import edu.stanford.rsl.conrad.data.numeric.Grid2D;
 import edu.stanford.rsl.conrad.data.numeric.Grid3D;
 import edu.stanford.rsl.conrad.filtering.ImageFilteringTool;
 import edu.stanford.rsl.conrad.opencl.OpenCLUtil;
+import edu.stanford.rsl.conrad.utils.UserUtil;
 
 /**
- * This is an abstract template for a filtering tool based on OpenCL. It already implements basic procedures, which can be overwritten by subclasses.  
- * @author Benedikt Lorch
+ * This is an abstract template for a filtering tool based on OpenCL.
+ * It already implements basic procedures, which can be overwritten by subclasses.  
+ * 
+ * @author Benedikt Lorch, Jennifer Maier
  *
  */
 public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 
 	private static final long serialVersionUID = -3133490195354195328L;
 
-	protected final int debug = 1;
-	
+	protected final int debug = 0;
+
 	// initialized in init method.
 	protected CLContext clContext;
 	protected CLDevice device;
@@ -40,62 +44,65 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 	protected int width;
 	protected int height;
 	protected int depth;
+	protected kernelname kernelName;
 	
-	protected final String KERNEL_FILE = "bilateralFilter3D.cl";
-	
-	/**
-	 * Return the filename which contains the kernel from derivated classes
-	 * @return kernelFile containing an implementation of the kernel which will be executed later
-	 */
-	protected String getKernelFile() {
-		return KERNEL_FILE;
+	public enum kernelname{
+		BILATERAL_FILTER_3D("bilateralFilter3D.cl"),
+		MEAN_FILTER_3D("meanFilter6Surrounding3D.cl"),
+		MEAN_FILTER_2D_IN_GRID3D("meanFilter2DinGrid3D.cl");
+		
+		private String filename;
+		
+		private kernelname(String fn){
+			this.filename = fn;
+		}
+		public String getName(){
+			return this.filename;
+		}
 	}
-	
-	
+
 	/**
 	 * Initializes input and output buffer, clContext, dimensions and builds the OpenCL program
 	 * @param width of the grids to process
 	 * @param height of the grids to process
 	 * @param depth of the grids to process
 	 */
+	@SuppressWarnings("unused")
 	public void init(int width, int height, int depth) {
 		if (!init) {
 			// Get dimensions from given grid
 			this.width = width;
 			this.height = height;
 			this.depth = depth;
-			
+
 			// Create OpenCL context and device if not done so yet
 			getDevice();
-			
+
 			// Allocate memory
 			image = clContext.createFloatBuffer(width * height * depth, CLMemory.Mem.READ_ONLY);
 			result = clContext.createFloatBuffer(width * height * depth, CLMemory.Mem.WRITE_ONLY);
-			
+
 			// Build OpenCL program and create kernel
-			String kernelFile = getKernelFile();
 			try {
-				InputStream input = OpenCLFilteringTool3D.class.getResourceAsStream(kernelFile);
+				InputStream input = OpenCLFilteringTool3D.class.getResourceAsStream(kernelName.filename);
 				if (null == input) {
-					throw new IOException("InputStream input is null." + kernelFile + " could not be loaded");
+					throw new IOException("InputStream input is null." + kernelName.filename + " could not be loaded");
 				}
-				
+
 				program = clContext.createProgram(input);
 				program.build();
 			} catch (IOException e) {
-				throw new RuntimeException("The kernel file " + kernelFile + " could not be loaded.", e);
+				throw new RuntimeException("The kernel file " + kernelName.filename + " could not be loaded.", e);
 			}
-			
+
 			if (debug > 0) {
 				System.out.println(program.getBuildStatus(device));
 				System.out.println(program.getBuildLog());
 			}
-			
+
 			init = true;
 		}
 	}
-	
-	
 	/**
 	 * Returns the device to be used. In case context or device have not been initalized yet, they will be created 
 	 * @return device to be used
@@ -111,15 +118,15 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 		return device;
 	}
 
-	
+
 	/**
 	 * Configures the filter kernel
 	 * Must set filterKernel = program.createCLKernel({kernelName})
 	 * Must do filterKernel.putArg(..) in order of kernel's parameters
 	 */
 	protected abstract void configureKernel();
-	
-	
+
+
 	/**
 	 * Called by process() before the processing begins. Put your write buffers to the queue here.
 	 * @param input Grid 3-D to be processed
@@ -131,98 +138,105 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 		image.getBuffer().rewind();
 		queue.putWriteBuffer(image, true);
 	}
-	
-	
+
+
 	/**
 	 * Called by process() after the processing. Put your read buffers to the queue here.
 	 * @param queue CommandQueue for the specific device
 	 * @return result as Grid 3-D
 	 */
+	@SuppressWarnings("unused")
 	protected Grid3D completeProcessing(CLCommandQueue queue) {
 		// Read back result with blocking call
 		queue.putReadBuffer(result, true);
-		
+
 		if (debug > 0) {
 			System.out.println("Retrieved the result buffer back from the GPU");
 		}
-		
+
 		// Copy the result from the buffer back into a Grid3D
 		FloatBuffer resultBuffer = result.getBuffer();
 		resultBuffer.rewind();
 		Grid3D result = bufferToGrid(resultBuffer, width, height, depth);		
 		resultBuffer.rewind();
-		
+
 		if (debug > 0) {
 			System.out.println("Transformed the result buffer back to a Grid 3-D");
 		}
 		return result;
 	}
-	
-	
+
+
 	/**
 	 * Applies the kernel to the given grid
 	 * @param grid 3-D image to filter
 	 * @return the filtered 3-D image
 	 */
+	@SuppressWarnings("unused")
 	public Grid3D process(Grid3D grid) {
 		try {
 			int size[] = grid.getSize();
 			// If not initialized yet, it's getting time
 			if (!init) {
+				if (this.kernelName == null) { // shouldn't happen
+					ArrayList<kernelname> availableKernelsList = new ArrayList<kernelname>(EnumSet.allOf(kernelname.class));
+					kernelname[] availableKernelsArray = availableKernelsList.toArray(new kernelname[availableKernelsList.size()]);
+					this.kernelName = (kernelname) UserUtil.chooseObject("Please select the 3D openCL filter you would like to apply", "Choose Filter", availableKernelsArray, kernelname.BILATERAL_FILTER_3D);
+				}
 				init(size[0], size[1], size[2]);
 			}
-			
-			
+
+
 			// Make sure that dimensions do match
 			if (width != size[0]
 					|| height != size[1]
 					|| depth != size[2]) {
 				throw new IllegalArgumentException("The given grid's dimensions are not equal to the sizes which this filter has been configured for.");
 			}
-			
+
 			CLCommandQueue queue = device.createCommandQueue();
-			
+
 			// Copy image data into linear floatBuffer
 			prepareProcessing(grid, queue);
-	
+
 			// Create filter kernel and put args
 			configureKernel();
-			
+
 			// GPU dependent constraints:
 			// localWorkSizeX * localWorkSizeY * localWorkSizeZ <= kernel.getWorkGroupSize(device)
 			// Each individual dimension <= device.getMaxWorkItemSizes()
 			long workGroupSize = filterKernel.getWorkGroupSize(device);
-			
+
 			// Cube root will usually not result in integer
 			int groupSize = (int) Math.ceil(Math.pow(workGroupSize, 1.0/3));
 			groupSize = (groupSize * groupSize * groupSize > workGroupSize) ? groupSize - 1 : groupSize;
-			
+
 			if (debug > 0) {
 				System.out.println("Starting processing on GPU");
 			}
-			
+
 			// Enqueue the filter kernel
 			queue.put3DRangeKernel(filterKernel, 0, 0, 0, OpenCLUtil.roundUp(groupSize, width), OpenCLUtil.roundUp(groupSize, height), OpenCLUtil.roundUp(groupSize, depth), groupSize, groupSize, groupSize);
 			queue.flush();
 			queue.finish();
-			
+
 			if (debug > 0) {
 				System.out.println("Finished processing on GPU");
 			}
-			
+
 			Grid3D result = completeProcessing(queue);
-			
+
 			queue.release();
 			return result;
-		
+
 		} catch (Exception e) {
-			
+
 			e.printStackTrace();
 		}
 		return null;
 	}
-	
-	
+
+
 	/**
 	 * Copies the float data of a given grid into a linear float buffer
 	 * @param imageBuffer: destination buffer
@@ -238,8 +252,8 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 		}
 		return imageBuffer;
 	}
-	
-	
+
+
 	/**
 	 * Copies the float buffer as linear memory into a Grid 3-D
 	 * @param FloatBuffer buffer as linear memory
@@ -251,7 +265,7 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 	protected Grid3D bufferToGrid(FloatBuffer buffer, int width, int height, int depth) {
 		Grid3D grid = new Grid3D(width, height, depth, false);
 		buffer.rewind();
-		
+
 		for (int i=0; i<depth; i++) {
 			float[] plane = new float[width * height];	
 			buffer.get(plane);
@@ -261,23 +275,30 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 		return grid;
 	}
 
+	public void setKernelName(kernelname kernelName) {
+		this.kernelName = kernelName;
+	}
+	
+	public kernelname getKernelName() {
+		return this.kernelName;
+	}
 
 	@Override
 	public void prepareForSerialization() {
 		init = false;
 	}
-	
-	
+
+
 	public void cleanup(){
 		release();
 	}
 
-	
+
 	protected void release(){
 		image.release();
 		result.release();
 		filterKernel.release();
 		OpenCLUtil.releaseContext(clContext);
 	}
-	
+
 }

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool3D.java
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/OpenCLFilteringTool3D.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Benedikt Lorch, Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.filtering.opencl;
 
 import java.io.IOException;
@@ -302,3 +306,8 @@ public abstract class OpenCLFilteringTool3D extends ImageFilteringTool {
 	}
 
 }
+
+/*
+ * Copyright (C) 2018 Benedikt Lorch, Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/binarization2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/binarization2D.cl
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2017 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+ #define POS(x, y) ((x) + ((y) * width))
+ 
+kernel void binarization2D(global float * image, global float * out, int width, int height, float thres)
+{
+	int gidX = get_global_id(0);
+	int gidY = get_global_id(1);
+	
+	// Make sure that coordinates are in range
+	if (gidX < 0 || gidY < 0 ||
+		gidX > width-1 || gidY > height-1)
+	{
+		return;
+	}
+
+	out[POS(gidX, gidY)] = (image[POS(gidX, gidY)] >= thres) ? 1.0 : 0.0;
+	return;
+}
+

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/binarization2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/binarization2D.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jennifer Maier
+ * Copyright (C) 2018 Jennifer Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
  #define POS(x, y) ((x) + ((y) * width))

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/kernel3x3Filter2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/kernel3x3Filter2D.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jennifer Maier
+ * Copyright (C) 2018 Jennifer Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
  #define POS(x, y) ((x) + ((y) * width))

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/kernel3x3Filter2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/kernel3x3Filter2D.cl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+ #define POS(x, y) ((x) + ((y) * width))
+ 
+kernel void kernel3x3Filter2D(global float * image, global float * out, int width, int height, int kernelWidth, global float* kernelArray)
+{
+	int gidX = get_global_id(0);
+	int gidY = get_global_id(1);
+	
+	// Make sure that coordinates are in range
+	if (gidX < kernelWidth/2 || gidY < kernelWidth/2 ||
+		gidX > width-kernelWidth/2-1 || gidY > height-kernelWidth/2-1)
+	{
+		return;
+	}
+	
+	// sum up over kernel
+	float sum = 0.0;
+	int count = 0;
+	for (int i = gidX - kernelWidth/2; i <= gidX + kernelWidth/2; i++) {
+		for (int j = gidY - kernelWidth/2; j <= gidY + kernelWidth/2; j++) {
+		
+			sum += image[POS(i, j)] * kernelArray[count++];
+		
+		}
+	}
+	out[POS(gidX, gidY)] = sum; 
+	return;
+}
+

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2D.cl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+ #define POS(x, y) ((x) + ((y) * width))
+ 
+kernel void meanFilter2D(global float * image, global float * out, int width, int height, int kernelWidth, int kernelHeight, float factor)
+{
+	int gidX = get_global_id(0);
+	int gidY = get_global_id(1);
+	
+	// Make sure that coordinates are in range
+	if (gidX < kernelWidth/2 || gidY < kernelHeight/2 ||
+		gidX > width-kernelWidth/2-1 || gidY > height-kernelHeight/2-1)
+	{
+		return;
+	}
+	
+	// sum up over kernel
+	float sum = 0.0;
+	for (int i = gidX - kernelWidth/2; i <= gidX + kernelWidth/2; i++) {
+		for (int j = gidY - kernelHeight/2; j <= gidY + kernelHeight/2; j++) {
+		
+			sum += image[POS(i, j)];
+		
+		}
+	}
+	out[POS(gidX, gidY)] = factor * sum; 
+	return;
+}
+

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2D.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jennifer Maier
+ * Copyright (C) 2018 Jennifer Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
  #define POS(x, y) ((x) + ((y) * width))

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2DinGrid3D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2DinGrid3D.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jennifer Maier
+ * Copyright (C) 2018 Jennifer Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
  #define POS(x, y, z) ((x) + ((y) * width) + ((z) * width * height))

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2DinGrid3D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter2DinGrid3D.cl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+ #define POS(x, y, z) ((x) + ((y) * width) + ((z) * width * height))
+ 
+kernel void meanFilter2DinGrid3D(global float * image, global float * out, int width, int height, int depth, int kernelWidth, int kernelHeight, float factor)
+{
+	int gidX = get_global_id(0);
+	int gidY = get_global_id(1);
+	int gidZ = get_global_id(2);
+	
+	// Make sure that coordinates are in range
+	if (gidX < kernelWidth/2 || gidY < kernelHeight/2 || gidZ < 0 ||
+		gidX > width-kernelWidth/2-1 || gidY > height-kernelHeight/2-1 || gidZ > depth-1)
+	{
+		return;
+	}
+	
+	// sum up over kernel
+	double sum = 0.0;
+	for (int i = gidX - kernelWidth/2; i <= gidX + kernelWidth/2; i++) {
+		for (int j = gidY - kernelHeight/2; j <= gidY + kernelHeight/2; j++) {
+		
+			sum += image[POS(i, j, gidZ)];
+		
+		}
+	}
+
+	out[POS(gidX, gidY, gidZ)] = factor * sum; 
+}
+

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter6Surrounding3D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter6Surrounding3D.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Jennifer Maier
+ * Copyright (C) 2018 Jennifer Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
  #define POS(x, y, z) ((x) + ((y) * width) + ((z) * width * height))

--- a/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter6Surrounding3D.cl
+++ b/src/edu/stanford/rsl/conrad/filtering/opencl/meanFilter6Surrounding3D.cl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Jennifer Maier
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+ */
+ #define POS(x, y, z) ((x) + ((y) * width) + ((z) * width * height))
+ 
+ kernel void meanFilter6Surrounding3D(global float * image, global float * out, global float * computeValue, int width, int height, int depth)
+{
+	int gidX = get_global_id(0);
+	int gidY = get_global_id(1);
+	int gidZ = get_global_id(2);
+	
+	// Make sure that coordinates are in range
+	if (gidX < 0 || gidY < 0 || gidZ < 0 ||
+		gidX >= width || gidY >= height || gidZ >= depth)
+	{
+		return;
+	}
+	
+	if (computeValue[POS(gidX, gidY, gidZ)] == 0 || gidX == 0 || gidY == 0 || gidZ == 0 ||
+		gidX == width-1 || gidY == height-1 || gidZ == depth-1)
+	{
+		out[POS(gidX, gidY, gidZ)] = image[POS(gidX, gidY, gidZ)];
+	}
+	else
+	{
+		out[POS(gidX, gidY, gidZ)] = 1.0/6.0 * image[POS(gidX-1, gidY, gidZ)] + 1.0/6.0 * image[POS(gidX+1, gidY, gidZ)]
+									 + 1.0/6.0 * image[POS(gidX, gidY-1, gidZ)] + 1.0/6.0 * image[POS(gidX, gidY+1, gidZ)]
+									 + 1.0/6.0 * image[POS(gidX, gidY, gidZ-1)] + 1.0/6.0 * image[POS(gidX, gidY, gidZ+1)]; 
+	}
+	
+}


### PR DESCRIPTION
**Apply_Filter.java**
- If a filter is called from ImageJ using Plugins -> CONRAD -> Apply Filter, the available Filters are now ordered alphabetically.
- Usage of 2D and 3D OpenCL Filters was implemented/generalized

**OpenCLFilteringTool2D.java, OpenCLFilteringTool3D.java**
- Adapted class for 3D OpenCL Filtering to be more general, now more implementations can be added/used. For each implemented Filter, there is an enumeration object connecting the filter's name to its .cl-Implementation file. If a new filter is implemented, a corresponding element has to be added to this enumeration and has to be set in the constructor of the filter implementation.
- Created abstract class for 2D OpenCL Filtering with similar structure as OpenCLFilteringTool3D

**Implementations of 2D and 3D Filters (.java and .cl files)**
- 2D filters: Mean Filter of arbitrary kernel size, Binarization Filter with arbitrary threshold, Filter with arbitrary 3x3 kernel
- 3D filters: Mean Filter using 6-connected voxels, arbitrary 2D Mean Filter for each individual 2D slice of a 3D Grid, Bilateral Filter was adapted to match new structure but functionality stays the same