### PR TITLE
SimpleMatrix: Changed internal buffer from double[][] to linear double[]

### DIFF
--- a/src/edu/stanford/rsl/conrad/geometry/shapes/mesh/DataMatrix.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/mesh/DataMatrix.java
@@ -101,10 +101,8 @@ public class DataMatrix extends SimpleMatrix{
 	public DataMatrix(DataMatrix otherMat) {
 		this.setDimensions(otherMat.getRows()/otherMat.dimension,otherMat.dimension,otherMat.getCols());
 		
-		this.buf = new double[otherMat.buf.length][otherMat.buf[0].length];
-		for( int i = 0; i < otherMat.buf.length; i++ ) {
-			System.arraycopy(otherMat.buf[i], 0, this.buf[i], 0, otherMat.buf[i].length);
-		}
+		this.buf = new double[otherMat.buf.length];
+		System.arraycopy(otherMat.buf, 0, this.buf, 0, otherMat.buf.length);
 		this.scaling = otherMat.scaling;
 		this.consensus = otherMat.consensus;
 		this.centers = otherMat.centers;
@@ -269,7 +267,7 @@ public class DataMatrix extends SimpleMatrix{
 		if (this.rows != rows || this.cols != cols) {
 			this.rows = rows;
 			this.cols = cols;
-			this.buf = new double[this.rows][this.cols];
+			this.buf = new double[this.rows*this.cols];
 			
 			if(!USE_GPA){
 				this.centers = new ArrayList<PointND>(cols);
@@ -311,7 +309,7 @@ public class DataMatrix extends SimpleMatrix{
 		for (int r : selectRows) {
 			int subCol = 0;
 			for (int c : selectCols) {
-				subMatrix.buf[subRow][subCol] = this.buf[r][c];
+				subMatrix.buf[subRow*selectCols.length+subCol] = this.buf[r*this.cols+c];
 				++subCol;
 			}
 			++subRow;

--- a/src/edu/stanford/rsl/conrad/numerics/SimpleOperators.java
+++ b/src/edu/stanford/rsl/conrad/numerics/SimpleOperators.java
@@ -178,7 +178,21 @@ public abstract class SimpleOperators {
 		return result;
 	}
 	
-
+	/**
+	 * 
+	 * @param in The vector to process
+	 * @param fct A generic function, e.g. the absolute value
+	 * @return a vector with the function applied to all elements
+	 */
+	public static SimpleVector elementWiseOperator(final SimpleVector in, DoubleFunction fct){
+		SimpleVector out = in.clone();
+		for (int i = 0; i < out.getLen(); i++) {
+			out.setElementValue(i, fct.f(out.getElement(i)));
+			
+		}
+		return out;
+	}
+	
 	// **************************************************************** //
 	// ******************* Matrix/Matrix operators ******************** //
 	// **************************************************************** //

--- a/src/edu/stanford/rsl/conrad/numerics/SimpleVector.java
+++ b/src/edu/stanford/rsl/conrad/numerics/SimpleVector.java
@@ -395,7 +395,7 @@ public class SimpleVector implements Serializable {
 	public SimpleMatrix transposed() {
 		final SimpleMatrix result = new SimpleMatrix(1, this.len);
 		for (int i = 0; i < result.cols; ++i)
-			result.buf[0][i] = this.buf[i];
+			result.buf[0*result.cols+i] = this.buf[i];
 		return result;
 	}
 


### PR DESCRIPTION
**SimpleMatrix**
now uses a linear array for its internal data buffer.

Adressing the linear buffer in 2D matrix notation is handled analogeously to the Grid2D class.
`getAtIndex(r,c) -> idx = r * this.cols + c `

These changes don't affect any methods visible from the outside. Only internal data handling is changed for memory saving purposes.

**Motivation**
Prior to this change, matrices that were far from square (i.e. rows >> cols or vice versa), would require a different amount of allocated memory depending on whether they were transposed or not.
This is due to a java handlling 2D arrays as "arrays of arrays". Thus, it takes less memory to save 2 arrays of 1000 values each (=double[2][1000]) than 1000 arrays of 2 each (=double[10000][2]).

*Minor Changes*
to SimpleVector & DataMatrix in accordance with the new buffer structure.
to SimpleOperators adding an elementsWise Operator for SimpleVectors expecting a DoubleFunction.
to SimpleMatrix adding a float[][] otherBuffer constructor.