### PR TITLE
Extend ImageUtil.wrapGrid to handle also Grid4D

### DIFF
--- a/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
+++ b/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
@@ -34,6 +34,7 @@ import ij.measure.Calibration;
 import ij.plugin.HyperStackConverter;
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
+import java.lang.IllegalArgumentException;
 
 public abstract class ImageUtil {
 
@@ -219,6 +220,9 @@ public abstract class ImageUtil {
 					setCalibrationToImagePlus2D(iPlus, grid);
 					return iPlus;
 				}
+			}
+			else {
+				throw new IllegalArgumentException("grid must be either a Grid1D, Grid2D, Grid4D!");
 			}
 		}
 		return null;

--- a/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
+++ b/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
@@ -188,7 +188,9 @@ public abstract class ImageUtil {
 	 */
 	public static ImagePlus wrapGrid(NumericGrid grid, String title) {
 		if (grid != null) {
-			if (grid instanceof Grid3D)
+			if (grid instanceof Grid4D)
+				return wrapGrid4D((Grid4D) grid, title);
+			else if (grid instanceof Grid3D)
 				return wrapGrid3D((Grid3D) grid, title);
 			else if (grid instanceof Grid2D) {
 				if (grid instanceof MultiChannelGrid2D) {

--- a/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
+++ b/src/edu/stanford/rsl/conrad/utils/ImageUtil.java
@@ -222,7 +222,7 @@ public abstract class ImageUtil {
 				}
 			}
 			else {
-				throw new IllegalArgumentException("grid must be either a Grid1D, Grid2D, Grid4D!");
+				throw new IllegalArgumentException("grid must be either a Grid1D, Grid2D, Grid3D or Grid4D!");
 			}
 		}
 		return null;


### PR DESCRIPTION
ImageUtils.warpGrid returns null if called with a Grid4D, instead of simply calling wrapGrid4D.
This PR makes all pyconrad tests pass.

Btw. shouldn't this method throw instead of returning null at cases it cannot handle?
