### PR TITLE
Pyconrad integration

### DIFF
--- a/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
@@ -17,11 +17,6 @@ public class PyConrad {
 		
 	}
 	
-	public void importModule(String module)
-	{
-		pythonCallback.importModule(this, module);
-	}
-	
 	public Object eval(String code, Object... args)
 	{
 		if(pythonCallback != null) {

--- a/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
@@ -44,7 +44,7 @@ public class PyConrad {
 		}
 	}
 
-	public boolean isAutoConvertConardGrids() {
+	public boolean getAutoConvertConardGrids() {
 		return autoConvertConradGrids;
 	}
 

--- a/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
@@ -1,0 +1,56 @@
+package edu.stanford.rsl.conrad.pyconrad;
+
+import java.lang.Object;
+import java.lang.RuntimeException;
+import edu.stanford.rsl.conrad.pyconrad.PythonCallback;
+
+
+public class PyConrad {
+	
+	private boolean autoConvertConradGrids = true;
+	private static PythonCallback pythonCallback; // this is set by pyconrad
+
+	
+	public PyConrad()
+	{
+		
+	}
+	
+	public void importModule(String module)
+	{
+		pythonCallback.importModule(this, module);
+	}
+	
+	public Object eval(String code, Object... args)
+	{
+		if(pythonCallback != null) {
+			return pythonCallback.eval(this, code, args);
+		} else {
+			throw new RuntimeException("JVM must be launched by pyconrad!\n" +
+					"Use \"pyconrad_run\" in your shell to launch Java by pyconrad.");
+		}
+	}
+	
+	public void exec(String code, Object... args)
+	{
+		if(pythonCallback != null) {
+			pythonCallback.exec(this, code, args);
+		} else {
+			throw new RuntimeException("JVM must be launched by pyconrad!\n" +
+					"Use \"pyconrad_run\" in your shell to launch Java by pyconrad.");
+		}
+	}
+
+	public boolean isAutoConvertConardGrids() {
+		return autoConvertConradGrids;
+	}
+
+	public void setAutoConvertConardGrids(boolean autoConvertConardGrids) {
+		this.autoConvertConradGrids = autoConvertConardGrids;
+	}
+	
+	public boolean isPyConradAvailable() 
+	{
+		return (pythonCallback != null);
+	}
+}

--- a/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2010-2018 Stefan Seitz
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.pyconrad;
 
 import java.lang.Object;

--- a/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PyConrad.java
@@ -8,6 +8,7 @@ import edu.stanford.rsl.conrad.pyconrad.PythonCallback;
 public class PyConrad {
 	
 	private boolean autoConvertConradGrids = true;
+	private boolean throwIfPythonIsNotAvailable = true;
 	private static PythonCallback pythonCallback; // this is set by pyconrad
 
 	
@@ -25,9 +26,11 @@ public class PyConrad {
 	{
 		if(pythonCallback != null) {
 			return pythonCallback.eval(this, code, args);
-		} else {
+		} else if(throwIfPythonIsNotAvailable) {
 			throw new RuntimeException("JVM must be launched by pyconrad!\n" +
 					"Use \"pyconrad_run\" in your shell to launch Java by pyconrad.");
+		} else {
+			return null;
 		}
 	}
 	
@@ -35,7 +38,7 @@ public class PyConrad {
 	{
 		if(pythonCallback != null) {
 			pythonCallback.exec(this, code, args);
-		} else {
+		} else if(throwIfPythonIsNotAvailable) {
 			throw new RuntimeException("JVM must be launched by pyconrad!\n" +
 					"Use \"pyconrad_run\" in your shell to launch Java by pyconrad.");
 		}
@@ -52,5 +55,13 @@ public class PyConrad {
 	public boolean isPyConradAvailable() 
 	{
 		return (pythonCallback != null);
+	}
+
+	public boolean getThrowIfPythonIsNotAvailable() {
+		return throwIfPythonIsNotAvailable;
+	}
+
+	public void setThrowIfPythonIsNotAvailable(boolean throwIfPythonIsNotAvailable) {
+		this.throwIfPythonIsNotAvailable = throwIfPythonIsNotAvailable;
 	}
 }

--- a/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
@@ -5,7 +5,6 @@ import edu.stanford.rsl.conrad.pyconrad.PyConrad;
 
 public interface PythonCallback {
 	
-	public void importModule(PyConrad object, String module);
 	public void exec(PyConrad object, String code, Object... args );
 	public Object eval(PyConrad object, String code, Object... args );
 

--- a/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
@@ -1,0 +1,12 @@
+package edu.stanford.rsl.conrad.pyconrad;
+
+import java.lang.Object;
+import edu.stanford.rsl.conrad.pyconrad.PyConrad;
+
+public interface PythonCallback {
+	
+	public void importModule(PyConrad object, String module);
+	public void exec(PyConrad object, String code, Object... args );
+	public Object eval(PyConrad object, String code, Object... args );
+
+}

--- a/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
+++ b/src/edu/stanford/rsl/conrad/pyconrad/PythonCallback.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2010-2018 Stefan Seitz
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.conrad.pyconrad;
 
 import java.lang.Object;

--- a/src/edu/stanford/rsl/tutorial/pyconrad/PyConradExample.java
+++ b/src/edu/stanford/rsl/tutorial/pyconrad/PyConradExample.java
@@ -1,0 +1,38 @@
+package edu.stanford.rsl.tutorial.pyconrad;
+
+import edu.stanford.rsl.conrad.pyconrad.PyConrad;
+import edu.stanford.rsl.conrad.data.numeric.Grid3D;
+
+public class PyConradExample {
+
+	public static void main(String[] args) {
+		
+		// Execute Python functions
+		PyConrad pyconrad = new PyConrad();
+		pyconrad.exec("print('Python rocks!')");
+		pyconrad.exec("print(args[0])", "hallo");
+		long two = (long) pyconrad.eval("1+1");
+		System.out.println(two);
+		
+		// Grids are automatically converted to numpy and vice-versa
+        // (can be deactivated by pyconrad.setAutoConvertConradGrids(false))
+		pyconrad.exec("import numpy as np");
+		Grid3D random = (Grid3D) pyconrad.eval("np.random.rand(20,30,10)");
+		random.show();
+		
+		Grid3D randomPlusOne = (Grid3D) pyconrad.eval("args[0]+1", random);
+		randomPlusOne.show();
+		
+		// Execute C++ functions (automatic compilation if necessary, see square.cpp)
+		pyconrad.exec("cpp_module = __import__('cppimport').imp('src.edu.stanford.rsl.tutorial.pyconrad.square')");
+		Grid3D squared = (Grid3D) pyconrad.eval("cpp_module.square(args[0])", randomPlusOne);
+		squared.show();
+		
+		// Different instances have separated variables
+		PyConrad otherPyConrad = new PyConrad();
+		otherPyConrad.exec("x=1");
+		otherPyConrad.exec("print('x is in locals(): ' + str('x' in locals()))");
+		pyconrad.exec("print('x is in locals(): ' + str('x' in locals()))");
+	}
+
+}

--- a/src/edu/stanford/rsl/tutorial/pyconrad/PyConradExample.java
+++ b/src/edu/stanford/rsl/tutorial/pyconrad/PyConradExample.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2010-2018 Stefan Seitz
+ * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
+*/
 package edu.stanford.rsl.tutorial.pyconrad;
 
 import edu.stanford.rsl.conrad.pyconrad.PyConrad;

--- a/src/edu/stanford/rsl/tutorial/pyconrad/square.cpp
+++ b/src/edu/stanford/rsl/tutorial/pyconrad/square.cpp
@@ -1,0 +1,36 @@
+/*
+<%
+setup_pybind11(cfg)
+%>
+*/
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <iostream>
+
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+py::array_t<float> square(py::array_t<float> input)
+{
+	py::array_t<float> rtn({input.shape(0), input.shape(1), input.shape(2)});
+
+	std::cout << "Hello from C++" << std::endl;
+	auto a = input.template unchecked<3>();
+	auto b = rtn.template mutable_unchecked<3>();
+
+	for(int z = 0; z < a.shape(0); ++z) {
+		for ( int y = 0; y < a.shape(1); y++ ) {
+			for ( int x = 0; x < a.shape(2); x++ ) {
+				b( z,y,x ) = a( z,y,x ) * a( z,y,x );
+			}
+		}
+	}
+	return rtn;
+}
+
+PYBIND11_MODULE( square, m )
+{
+	m.def("square", &square, "a"_a = "Numpy array to square");
+}


### PR DESCRIPTION
This PR adds Python integration to CONRAD. You can execute arbitrary Python commands from Java using the class edu.standford.rsl.conrad.pyconrad.PyConrad. Conversions NumericGrid <-> NumPy are handled automatically.

This is useful if you have an already existing Java project but need some Python or C++ routine that is not available for Java (plotting etc.). Note that you can also import C++ modules (automatic compilation). Since the magic is done by pyconrad (requires newest version) you have to launch your JVM via:

     pyconrad_run --gui edu.stanford.rsl.tutorial.pyconrad.PyConradExample --dev_path /home/stephan/projects/CONRAD

The executable `pyconrad_run` should be automatically in your $PATH after installing pyconrad (it should be in the subfolder ./bin in the case of a pipenv). If pyconrad is not available, you can choose whether the Python calls are ignored or throw an exception.