### PR TITLE
Potential release V 1.1.0 - Full class parsing support when executing CONRAD from *.jar

### DIFF
--- a/src/edu/stanford/rsl/conrad/utils/CONRAD.java
+++ b/src/edu/stanford/rsl/conrad/utils/CONRAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017  Andreas Maier
+ * Copyright (C) 2010-2019  Andreas Maier
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
  */
 package edu.stanford.rsl.conrad.utils;
@@ -25,7 +25,7 @@ import ij.ImageJ;
 import edu.stanford.rsl.apps.gui.RawDataOpener;
 
 public abstract class CONRAD {
-	public static final String VersionString = "Version 1.0.9";
+	public static final String VersionString = "Version 1.1.0";
 	public static final String CONRADBibtex = "@article{Maier13-CSF," +
 			"  author = {A. Maier, H. G. Hofmann, M. Berger, P. Fischer, C. Schwemmer, H. Wu, K. Müller, J. Hornegger, J. H. Choi, C. Riess, A. Keil, and R. Fahrig},\n" +
 			"  title={{CONRAD - A software framework for cone-beam imaging in radiology}},\n" +

--- a/src/edu/stanford/rsl/conrad/utils/CONRAD.java
+++ b/src/edu/stanford/rsl/conrad/utils/CONRAD.java
@@ -9,12 +9,16 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import ij.IJ;
 import ij.ImageJ;
@@ -275,6 +279,39 @@ public abstract class CONRAD {
 		while (resources.hasMoreElements()) {
 			URL resource = resources.nextElement();
 			String filename = resource.getFile();
+			
+			// Get URI from resource
+			URI uri = null;
+			try {
+				uri = resource.toURI();
+			} catch (URISyntaxException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			
+			// Check whether CONRAD was executed from jar file
+			if(uri.getScheme().equals("jar")) {
+				// System.out.println("Parsing style: Conrad jar version.");
+				
+				// Find the path to the root jar file
+				String jarFileName = filename.split("!")[0];
+				JarFile jar = null;
+				try {
+					jar = new JarFile(new File(new URI(jarFileName)));
+				} catch (URISyntaxException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				
+				// Extract the classes
+				ArrayList<Class<? extends Object>> classes = findClassesInJar(jar,path);
+				jar.close();
+				
+				return classes;
+				// We're done with the jar case, everything below is non-jar parsing
+			}
+			// System.out.println("Parsing style: Conrad eclipse version.");
+			
 			if (filename.contains("%20")) filename = filename.replace("%20", " ");
 			dirs.add(new File(filename));
 		}
@@ -322,6 +359,42 @@ public abstract class CONRAD {
 		return classes;
 	}
 
+	/**
+	 * Iterative method used to find all classes in a given directory and subdirs packed in a *.jar file.
+	 *
+	 * @param jar   The directory location of the jar file
+	 * @param packageName The package name for classes found inside the base directory
+	 * @return The classes
+	 * @throws ClassNotFoundException
+	 */
+	private static ArrayList<Class<? extends Object>> findClassesInJar(JarFile jar, String packageName) throws ClassNotFoundException {
+		ArrayList<Class<? extends Object>> classes = new ArrayList<Class<? extends Object>>();
+		Enumeration<JarEntry> jarIterator = jar.entries();
+		
+		while (jarIterator.hasMoreElements()) {
+			JarEntry entr = jarIterator.nextElement();
+			if (entr != null && entr.getName().contains(packageName)) {
+				// System.out.println(entr.getName() + " " + entr.isDirectory());
+				if(!entr.isDirectory() && entr.getName().endsWith(".class")) {
+					try{
+						classes.add(Class.forName(entr.getName().substring(0, entr.getName().length() - 6).replace("/", ".")));
+					} catch (UnsatisfiedLinkError e){
+						/**
+						 * We skip over classes that cannot be loaded (compilation errors, etc.).
+						 */
+						//System.out.println("skipping " + file);
+					} catch (NoClassDefFoundError e2){
+						/**
+						 * We skip over classes that cannot be loaded (compilation errors, etc.).
+						 */
+						//System.out.println("skipping " + file);
+					}
+				}
+			}
+		}
+		return classes;
+	}
+	
 	/**
 	 * Method to log something in a log file.
 	 * Currently it just redirects to IJ.log method.

--- a/src/edu/stanford/rsl/tutorial/physics/DistributionTest.java
+++ b/src/edu/stanford/rsl/tutorial/physics/DistributionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - Andreas Maier, Oliver Taubmann, Fabian Rückert 
+ * Copyright (C) 2014 - Andreas Maier, Oliver Taubmann, Fabian RÃ¼ckert 
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 package edu.stanford.rsl.tutorial.physics;

--- a/src/edu/stanford/rsl/tutorial/physics/NHelperFkt.java
+++ b/src/edu/stanford/rsl/tutorial/physics/NHelperFkt.java
@@ -10,7 +10,7 @@ import edu.stanford.rsl.conrad.numerics.SimpleMatrix;
 import edu.stanford.rsl.conrad.numerics.SimpleOperators;
 import edu.stanford.rsl.conrad.numerics.SimpleVector;
 
-public abstract class nHelperFkt {
+public abstract class NHelperFkt {
 
 	/**
 	 * Helper Function calculating the cross product of 2 3D vectors a x b

--- a/src/edu/stanford/rsl/tutorial/physics/SingleMaterialMonteCarlo.java
+++ b/src/edu/stanford/rsl/tutorial/physics/SingleMaterialMonteCarlo.java
@@ -17,7 +17,7 @@ import edu.stanford.rsl.conrad.physics.materials.utils.AttenuationType;
 /**
  * Simple single-threaded Monte Carlo Simulation of photons passing through one material.
  * 
- * @author Fabian Rückert
+ * @author Fabian RÃ¼ckert
  * 
  */
 public class SingleMaterialMonteCarlo {
@@ -89,9 +89,7 @@ public class SingleMaterialMonteCarlo {
 		 visualizeKleinNishina(140000*eV);
 
 		// visualizeKleinNishina(2.75*eV);
-		//
 		// visualizeKleinNishina(55000*eV);
-
 	}
 
 	private void raytrace(double energyEV, int numRays) {
@@ -146,8 +144,6 @@ public class SingleMaterialMonteCarlo {
 			return;
 		} else {
 			// compton scattering
-
-
 			energyEV = sampler.sampleComptonScattering(energyEV, dir);
 
 			// send new ray

--- a/src/edu/stanford/rsl/tutorial/physics/XRayAnalytics.java
+++ b/src/edu/stanford/rsl/tutorial/physics/XRayAnalytics.java
@@ -120,7 +120,7 @@ public class XRayAnalytics {
 			return -1;
 		}
 		
-		return nHelperFkt.computeRMSE(first, second);
+		return NHelperFkt.computeRMSE(first, second);
 	}
 	
 	public static double averageRMSE(String firstFileName, String secondFileName){
@@ -136,10 +136,10 @@ public class XRayAnalytics {
 			return -1;
 		}
 		
-		Grid2D a = nHelperFkt.compareToAveragePixel(first);
-		Grid2D b = nHelperFkt.compareToAveragePixel(second);
+		Grid2D a = NHelperFkt.compareToAveragePixel(first);
+		Grid2D b = NHelperFkt.compareToAveragePixel(second);
 		
-		return nHelperFkt.computeRMSE(a, b);
+		return NHelperFkt.computeRMSE(a, b);
 	}
 	
 	/**

--- a/src/edu/stanford/rsl/tutorial/physics/XRayTracer.java
+++ b/src/edu/stanford/rsl/tutorial/physics/XRayTracer.java
@@ -44,7 +44,7 @@ import edu.stanford.rsl.tutorial.physics.workingClass.*;
 /**
  * A raytracer for X-rays using the PriorityRaytracer for intersection calculation. It considers only the Compton and the Photoelectric Effect, disregarding other effects which are insignificant for X-rays.
  *
- * @author Fabian R�ckert, Tobias Miksch
+ * @author Fabian Rückert, Tobias Miksch
  *
  */
 public class XRayTracer {
@@ -413,16 +413,16 @@ public class XRayTracer {
 			}
 			
 			if (tracingVersion == 0 || tracingVersion == 1) {
-				rayTraceThreads[i] = new rayWorker(raytracer, new RaytraceResult(), numberofrays, startEnergyEV, grid,
+				rayTraceThreads[i] = new RayWorker(raytracer, new RaytraceResult(), numberofrays, startEnergyEV, grid,
 						detector, traj.getProjectionMatrix(projectionIndex), INFINITE_SIMULATION, writeAdditionalData,
 						sourceDetectorDistance, pixelDimX, pixelDimY, background, tracingVersion, i, null, lightRayLength);
 			} else if (tracingVersion == 2) {
-				rayTraceThreads[i] = new virtualPointWorker(raytracer, new RaytraceResult(), numberofrays,
+				rayTraceThreads[i] = new VirtualPointWorker(raytracer, new RaytraceResult(), numberofrays,
 						startEnergyEV, grid, detector, traj.getProjectionMatrix(projectionIndex), INFINITE_SIMULATION,
 						writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, tracingVersion,
 						i, null, lightRayLength, virtualLightsPerThread, collection, attempting, barrier);
 			} else if (tracingVersion == 3) {
-				rayTraceThreads[i] = new virtualRayWorker(raytracer, new RaytraceResult(), numberofrays,
+				rayTraceThreads[i] = new VirtualRayWorker(raytracer, new RaytraceResult(), numberofrays,
 						startEnergyEV, grid, detector, traj.getProjectionMatrix(projectionIndex), INFINITE_SIMULATION,
 						writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, tracingVersion,
 						i, null, lightRayLength, virtualLightsPerThread, vrlColl, attempting, barrier);

--- a/src/edu/stanford/rsl/tutorial/physics/XRayTracerSampling.java
+++ b/src/edu/stanford/rsl/tutorial/physics/XRayTracerSampling.java
@@ -37,8 +37,8 @@ import edu.stanford.rsl.conrad.physics.materials.utils.AttenuationType;
 // ********************************************************************
 
 /**
- * Does the Monte Carlo sampling using a given Random object (for example ThreadLocalRandom)
- * @author Fabian R�ckert, Tobias Miksch
+ * Performs Monte Carlo sampling using a given Random object (for example ThreadLocalRandom)
+ * @author Fabian Rückert, Tobias Miksch
  */
 public class XRayTracerSampling {
 	
@@ -149,7 +149,7 @@ public class XRayTracerSampling {
 		//Geant4 Code ---------------------
 		
 		// transform scattered photon direction vector to world coordinate system		
-		SimpleVector resultdir = nHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
+		SimpleVector resultdir = NHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
 		dir.setSubVecValue(0, resultdir);
 
 		//convert back to eV
@@ -176,8 +176,8 @@ public class XRayTracerSampling {
 		gamDirection1.normalizeL2();
 		
 		// transform scattered photon direction vector to world coordinate system
-		SimpleVector ret = nHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
-		double radians = nHelperFkt.getAngleInRad(dir, ret);
+		SimpleVector ret = NHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
+		double radians = NHelperFkt.getAngleInRad(dir, ret);
 		dir.setSubVecValue(0, ret);
 		
 		return getScatteredPhotonEnergy(energyEV, radians);
@@ -201,7 +201,7 @@ public class XRayTracerSampling {
 		SimpleVector unitPoint = new SimpleVector(dirx, diry, dirz);
 		
 		SimpleVector ret = new SimpleVector(0.0, 0.0, 0.0);
-		ret = nHelperFkt.transformToWorldCoordinateSystem(unitPoint, dir);
+		ret = NHelperFkt.transformToWorldCoordinateSystem(unitPoint, dir);
 
 		return ret;
 	}
@@ -340,7 +340,7 @@ public class XRayTracerSampling {
 		double dist = detectorPoint.euclideanDistance(scatterPoint);
 		double dX = 1.0;
 		if(endPoint) {
-			dX 	= Math.cos( nHelperFkt.getAngleInRad(rayDirection, normalDetector) );
+			dX 	= Math.cos( NHelperFkt.getAngleInRad(rayDirection, normalDetector) );
 		}
 		return (dX * 1.0 / (dist * dist));
 	}

--- a/src/edu/stanford/rsl/tutorial/physics/XRayWorker.java
+++ b/src/edu/stanford/rsl/tutorial/physics/XRayWorker.java
@@ -23,9 +23,9 @@ import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 
 /**
- * Raytraces x-rays and saves the results.
+ * Raytraces X-rays and saves the results.
  * 
- * @author Fabian Rückert
+ * @author Fabian RÃ¼ckert
  */
 
 public class XRayWorker implements Runnable{

--- a/src/edu/stanford/rsl/tutorial/physics/package-info.java
+++ b/src/edu/stanford/rsl/tutorial/physics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Andreas Maier, Tobias Miksch, Fabian R�ckert
+ * Copyright (C) 2010-2014 Andreas Maier, Tobias Miksch, Fabian Rückert
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 package edu.stanford.rsl.tutorial.physics;
@@ -18,5 +18,5 @@ package edu.stanford.rsl.tutorial.physics;
  * Files created by this method can than be compared and analyzed with the XRayComperator. It can compare the values, the absolute values or use the 
  *  Root-Mean-Square Error or structural similarity index(SSIM) methods. 
  * 
- * @author Tobias Miksch based on the work of Fabian R�ckert
+ * @author Tobias Miksch based on the work of Fabian Rückert
  */

--- a/src/edu/stanford/rsl/tutorial/physics/workingClass/AbstractWorker.java
+++ b/src/edu/stanford/rsl/tutorial/physics/workingClass/AbstractWorker.java
@@ -27,12 +27,12 @@ import edu.stanford.rsl.conrad.rendering.PriorityRayTracer;
 import edu.stanford.rsl.conrad.utils.CONRAD;
 import edu.stanford.rsl.tutorial.physics.XRayHitVertex;
 import edu.stanford.rsl.tutorial.physics.XRayTracerSampling;
-import edu.stanford.rsl.tutorial.physics.nHelperFkt;
+import edu.stanford.rsl.tutorial.physics.NHelperFkt;
 import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 /**
  * Abstract class as a base for the different variations of the light transport algorithm
- * @author Tobias Miksch based on work of Fabian R�ckert
+ * @author Tobias Miksch based on work of Fabian Rückert
  */
 public abstract class AbstractWorker implements Runnable {
 
@@ -256,7 +256,7 @@ public abstract class AbstractWorker implements Runnable {
 			// System.out.print("\nCurrentLineSegment: " +
 			// currentLineSegment.getNameString());
 
-			if (foundStartSegment || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (foundStartSegment || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					rayPoint.getAbstractVector())) {
 				// get length between the raypoint and the next material in ray direction
 
@@ -478,7 +478,7 @@ public abstract class AbstractWorker implements Runnable {
 			end = reversed ? e.getPoint() : e.getEnd();
 
 			// Test if we are already behind the Detector or still out of the scene
-			if (foundStartSegment || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (foundStartSegment || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					rayPoint.getAbstractVector())) {
 
 				foundStartSegment = true;
@@ -493,7 +493,7 @@ public abstract class AbstractWorker implements Runnable {
 			}
 
 			// We went past the emitter and could not find an interaction point!
-			if (foundStartSegment && !nHelperFkt.isBetween(ray.getPoint().getAbstractVector(),
+			if (foundStartSegment && !NHelperFkt.isBetween(ray.getPoint().getAbstractVector(),
 					emitterPoint.getAbstractVector(), rayPoint.getAbstractVector())) {
 				// Case 2
 				return null;
@@ -637,7 +637,7 @@ public abstract class AbstractWorker implements Runnable {
 			// }
 
 			// if we are not between the two points any longer
-			if (foundStartSegment && !nHelperFkt.isBetween(startPoint.getAbstractVector(), endPoint.getAbstractVector(),
+			if (foundStartSegment && !NHelperFkt.isBetween(startPoint.getAbstractVector(), endPoint.getAbstractVector(),
 					start.getAbstractVector())) {
 				// System.out.println(currentLineSegment.getNameString() + " leaving
 				// Finished!\n");
@@ -648,7 +648,7 @@ public abstract class AbstractWorker implements Runnable {
 				return Math.exp(-throughput);
 			}
 
-			if (foundStartSegment || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (foundStartSegment || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					startPoint.getAbstractVector())) {
 				// get length between the raypoint and the next material in ray direction
 				if (!foundStartSegment) {
@@ -661,7 +661,7 @@ public abstract class AbstractWorker implements Runnable {
 					// System.out.println("Distance: " +
 					// shadowRay.getPoint().euclideanDistance(end));
 
-					if (nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+					if (NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 							endPoint.getAbstractVector())) {
 						// System.out.println("We end it here!");
 						distToNextMaterial = startPoint.euclideanDistance(endPoint);
@@ -678,7 +678,7 @@ public abstract class AbstractWorker implements Runnable {
 					// System.out.println(currentLineSegment.getNameString() + "-- starting the
 					// process!");
 				} else {
-					if (nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+					if (NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 							endPoint.getAbstractVector())) {
 						// System.out.println(" and add a little bit of: " +
 						// currentLineSegment.getNameString());

--- a/src/edu/stanford/rsl/tutorial/physics/workingClass/RayWorker.java
+++ b/src/edu/stanford/rsl/tutorial/physics/workingClass/RayWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - Andreas Maier, Fabian R�ckert, Tobias Miksch
+ * Copyright (C) 2014 - Andreas Maier, Fabian Rückert, Tobias Miksch
  * CONRAD is developed as an Open Source project under the GNU General Public License (GPL).
 */
 
@@ -19,18 +19,18 @@ import edu.stanford.rsl.conrad.physics.materials.Material;
 import edu.stanford.rsl.conrad.rendering.PriorityRayTracer;
 import edu.stanford.rsl.tutorial.physics.XRayHitVertex;
 import edu.stanford.rsl.tutorial.physics.XRayTracerSampling;
-import edu.stanford.rsl.tutorial.physics.nHelperFkt;
+import edu.stanford.rsl.tutorial.physics.NHelperFkt;
 import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 /**
  * Implementation of the ray tracing and bidirectional path tracing algorithms for the calculation of indirect illumination
- * @author Tobias Miksch based on work of Fabian R�ckert
+ * @author Tobias Miksch based on work of Fabian Rückert
  */
-public class rayWorker extends AbstractWorker {
+public class RayWorker extends AbstractWorker {
 
 	private int bdptConnections = 2;
 	
-	public rayWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV, Grid2D grid,
+	public RayWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV, Grid2D grid,
 			XRayDetector detector, Projection proj, boolean infinite, boolean writeAdditionalData,
 			double sourceDetectorDist, double pixelDimensionX, double pixelDimensionY, Material background,
 			int versionNumber, int threadNumber, Random random, int lightRayLength) {
@@ -214,7 +214,7 @@ public class rayWorker extends AbstractWorker {
 							StraightLine camRay = new StraightLine(randomDetectorPoint, vertexHit.getEndPoint());
 							camRay.normalize();
 
-							double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), vertexHit.getRayDir());
+							double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), vertexHit.getRayDir());
 							double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 
 							double energy = XRayTracerSampling.getScatteredPhotonEnergy(energyEV, theta);
@@ -245,7 +245,7 @@ public class rayWorker extends AbstractWorker {
 					StraightLine camRay = new StraightLine(randomDetectorPoint, vertexHit.getEndPoint());
 					camRay.normalize();
 
-					double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0),
+					double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0),
 							vertexHit.getRayDir());
 					double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 

--- a/src/edu/stanford/rsl/tutorial/physics/workingClass/TestControlUnit.java
+++ b/src/edu/stanford/rsl/tutorial/physics/workingClass/TestControlUnit.java
@@ -31,7 +31,7 @@ import edu.stanford.rsl.tutorial.physics.XRayHitVertex;
 import edu.stanford.rsl.tutorial.physics.XRayTracer;
 import edu.stanford.rsl.tutorial.physics.XRayTracerSampling;
 import edu.stanford.rsl.tutorial.physics.XRayVPL;
-import edu.stanford.rsl.tutorial.physics.nHelperFkt;
+import edu.stanford.rsl.tutorial.physics.NHelperFkt;
 import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 
@@ -41,8 +41,8 @@ import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
  */
 public class TestControlUnit extends AbstractWorker {
 
-	rayWorker rayTracer;
-	virtualPointWorker vplTracer;
+	RayWorker rayTracer;
+	VirtualPointWorker vplTracer;
 	
 	private volatile int attempting[];
 	private int vplPathNumber = 0;
@@ -74,8 +74,8 @@ public class TestControlUnit extends AbstractWorker {
 			sampler = new XRayTracerSampling(random, (width * pixelDimX), (height * pixelDimY), normalOfDetector);
 		}
 		
-		rayTracer = new rayWorker((PriorityRayTracer) raytracer, result, numRays, startEnergyEV, grid, detector, proj, infiniteSimulation, writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, version, threadNumber, random, lightRayLength);
-		vplTracer = new virtualPointWorker((PriorityRayTracer) raytracer, result, numRays, startEnergyEV, grid, detector, proj, infiniteSimulation, writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, version, threadNumber, random, lightRayLength, virtualLightsPerThread, collectionOfAllVPLs, attempting, barrierVPL);
+		rayTracer = new RayWorker((PriorityRayTracer) raytracer, result, numRays, startEnergyEV, grid, detector, proj, infiniteSimulation, writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, version, threadNumber, random, lightRayLength);
+		vplTracer = new VirtualPointWorker((PriorityRayTracer) raytracer, result, numRays, startEnergyEV, grid, detector, proj, infiniteSimulation, writeAdditionalData, sourceDetectorDistance, pixelDimX, pixelDimY, background, version, threadNumber, random, lightRayLength, virtualLightsPerThread, collectionOfAllVPLs, attempting, barrierVPL);
 		
 		double energyEV = startEnergyEV;
 
@@ -315,9 +315,9 @@ public class TestControlUnit extends AbstractWorker {
 		gamDirection1.normalizeL2();
 		
 		// transform scattered photon direction vector to world coordinate system
-		SimpleVector ret = nHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
+		SimpleVector ret = NHelperFkt.transformToWorldCoordinateSystem(gamDirection1, dir);
 		
-		double testingTheta = nHelperFkt.getAngleInRad(dir, ret);
+		double testingTheta = NHelperFkt.getAngleInRad(dir, ret);
 		if( Math.abs(theta - testingTheta) > 0.01 ) {
 			System.out.println("We have different angles in out function: " + theta + " & " + testingTheta);
 		}
@@ -355,12 +355,12 @@ public class TestControlUnit extends AbstractWorker {
 
 			System.out.print("\nWe iterate: " + currentLineSegment.getNameString());
 
-			if (nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					startPoint.getAbstractVector())) {
 				System.out.print(" --->  with startPoint");
 			}
 
-			if (nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					endPoint.getAbstractVector())) {
 				System.out.print(" --->  with endPoint");
 			}
@@ -438,7 +438,7 @@ public class TestControlUnit extends AbstractWorker {
 
 		System.out.println("Vectors: " + simple01 + " and " + simple10);
 
-		SimpleVector normal = nHelperFkt.crossProduct3D(simple01, simple10);
+		SimpleVector normal = NHelperFkt.crossProduct3D(simple01, simple10);
 
 		System.out.println("CrossProduct: " + normal);
 
@@ -829,7 +829,7 @@ public class TestControlUnit extends AbstractWorker {
 			for (int i = 0; i < count; ++i) {
 				SimpleVector dir = ray.getDirection().clone();
 				sampler.sampleComptonScattering(energyEV, dir);
-				double radians = nHelperFkt.getAngleInRad(ray.getDirection(), dir);
+				double radians = NHelperFkt.getAngleInRad(ray.getDirection(), dir);
 				int slot = (int) Math.floor((Math.toDegrees(radians)));
 				numberOfangles[slot] += 1;
 			}
@@ -960,7 +960,7 @@ public class TestControlUnit extends AbstractWorker {
 
 					double energy = testScattering(energyEV, dir, theta, phi);
 
-					double radians = nHelperFkt.getAngleInRad(ray.getDirection(), dir); // .multipliedBy(-1.0)
+					double radians = NHelperFkt.getAngleInRad(ray.getDirection(), dir); // .multipliedBy(-1.0)
 					double u = XRayTracerSampling.comptonAngleCrossSection(energy, radians);
 					// if(u>max) {
 					// max = u;
@@ -992,7 +992,7 @@ public class TestControlUnit extends AbstractWorker {
 			for (int i = 0; i < count; ++i) {
 				SimpleVector dir = ray.getDirection().clone();
 				sampler.sampleComptonScattering(energyEV, dir);
-				double radians = nHelperFkt.getAngleInRad(ray.getDirection(), dir);
+				double radians = NHelperFkt.getAngleInRad(ray.getDirection(), dir);
 				int slot = (int) Math.floor((samplingSize * Math.toDegrees(radians)));
 				numberOfangles[slot] += 1;
 			}
@@ -1051,7 +1051,7 @@ public class TestControlUnit extends AbstractWorker {
 			for (int i = 0; i < count; ++i) {
 				SimpleVector dir = ray.getDirection().clone();
 				sampler.sampleComptonScattering(energyEV, dir);
-				double radians = nHelperFkt.getAngleInRad(ray.getDirection(), dir);
+				double radians = NHelperFkt.getAngleInRad(ray.getDirection(), dir);
 				int slot = (int) Math.floor((samplingSize * Math.toDegrees(radians)));
 				numberOfangles[slot] += 1;
 			}
@@ -1099,7 +1099,7 @@ public class TestControlUnit extends AbstractWorker {
 
 				energy = testScattering(energyEV, dir, theta, phi);
 
-				double radians = nHelperFkt.getAngleInRad(ray.getDirection(), dir); // .multipliedBy(-1.0)
+				double radians = NHelperFkt.getAngleInRad(ray.getDirection(), dir); // .multipliedBy(-1.0)
 				double u = XRayTracerSampling.comptonAngleCrossSection(energy, radians);
 
 				// System.out.println("Point: " + t +":" + p + " has an angle of " +
@@ -1169,7 +1169,7 @@ public class TestControlUnit extends AbstractWorker {
 				StraightLine camera = new StraightLine(randomDetectorPoint, vpLight.getVplPos());
 				camera.normalize();
 
-				double theta = nHelperFkt.getAngleInRad(vpLight.getDirection(), camera.getDirection()); // .multipliedBy(-1.0)
+				double theta = NHelperFkt.getAngleInRad(vpLight.getDirection(), camera.getDirection()); // .multipliedBy(-1.0)
 				double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(vpLight.getEnergyEV(), theta);
 
 				double energy = XRayTracerSampling.getScatteredPhotonEnergy(vpLight.getEnergyEV(), theta);
@@ -1254,13 +1254,13 @@ public class TestControlUnit extends AbstractWorker {
 				SimpleVector v1 = shadowRay.getDirection();
 				SimpleVector v2 = lightVertex.getRayDir().multipliedBy(-1.0);
 
-				double radians = nHelperFkt.getAngleInRad(v1, v2);
-				double degree = nHelperFkt.getAngleInDeg(v1, v2);
+				double radians = NHelperFkt.getAngleInRad(v1, v2);
+				double degree = NHelperFkt.getAngleInDeg(v1, v2);
 
 				double changedEnergy = XRayTracerSampling.getScatteredPhotonEnergy(energyEV, radians);
 				double divison = changedEnergy / energyEV;
 
-				double scatterRad = nHelperFkt.transformToScatterAngle(radians);
+				double scatterRad = NHelperFkt.transformToScatterAngle(radians);
 				double scatterDeg = Math.toDegrees(scatterRad);
 
 				double crossRad = XRayTracerSampling.comptonAngleCrossSection(energyEV, scatterRad);
@@ -1444,7 +1444,7 @@ public class TestControlUnit extends AbstractWorker {
 				StraightLine camRay = new StraightLine(randomDetectorPoint, var);
 				camRay.normalize();
 
-				double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), ray.getDirection());
+				double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), ray.getDirection());
 				double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 				// double probability = XRayTracerSampling.angleProbabilityCompton(energyEV,
 				// theta);
@@ -1462,13 +1462,13 @@ public class TestControlUnit extends AbstractWorker {
 				// System.err.println("What is wrong with the transmittance?" + transmittance);
 
 				double dist = randomDetectorPoint.euclideanDistance(var); // * XRayTracer.milli
-				double phi = nHelperFkt.getAngleInRad(camRay.getDirection(), normalOfDetector);
+				double phi = NHelperFkt.getAngleInRad(camRay.getDirection(), normalOfDetector);
 				double dX = Math.cos(phi);
 				double dY = Math
-						.cos(nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), ray.getDirection()));
+						.cos(NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), ray.getDirection()));
 
 				StraightLine toMiddle = new StraightLine(middle, var);
-				double dZ = Math.cos(nHelperFkt.getAngleInRad(toMiddle.getDirection(), normalOfDetector));
+				double dZ = Math.cos(NHelperFkt.getAngleInRad(toMiddle.getDirection(), normalOfDetector));
 
 				// double g0erm = (pixelDimX * pixelDimY) * dX / dist / dist;
 				// double g1erm = (width * height) * dX / dist / dist ;
@@ -1558,7 +1558,7 @@ public class TestControlUnit extends AbstractWorker {
 				if (simulatedRays < 20) //
 					vizualizeRay(result, firstScatterPoint.getEndPoint(), randomDetectorPoint, Color.YELLOW, 10);
 
-				double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0),
+				double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0),
 						firstScatterPoint.getRayDir());
 				double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 
@@ -1567,7 +1567,7 @@ public class TestControlUnit extends AbstractWorker {
 						energy);
 
 				double dist = randomDetectorPoint.euclideanDistance(firstScatterPoint.getEndPoint());
-				double phi = nHelperFkt.getAngleInRad(camRay.getDirection(), normalOfDetector);
+				double phi = NHelperFkt.getAngleInRad(camRay.getDirection(), normalOfDetector);
 				double dX = Math.cos(phi);
 				double gTerm = ((width * pixelDimX * height * pixelDimY) * dX) / (dist * dist);
 
@@ -1663,7 +1663,7 @@ public class TestControlUnit extends AbstractWorker {
 						StraightLine camRay = new StraightLine(randomDetectorPoint, firstScatterPoint.getEndPoint());
 						camRay.normalize();
 
-						double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), firstScatterPoint.getRayDir());
+						double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), firstScatterPoint.getRayDir());
 						double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 
 						double energy = XRayTracerSampling.getScatteredPhotonEnergy(energyEV, theta);
@@ -1690,7 +1690,7 @@ public class TestControlUnit extends AbstractWorker {
 			StraightLine lightRay = new StraightLine(camPathVertex.getEndPoint(), emitterPoint);
 			lightRay.normalize();
 			
-			double theta = nHelperFkt.getAngleInRad(camRay.getDirection(), lightRay.getDirection());
+			double theta = NHelperFkt.getAngleInRad(camRay.getDirection(), lightRay.getDirection());
 			double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 
 			double energy = XRayTracerSampling.getScatteredPhotonEnergy(energyEV, theta);
@@ -1736,7 +1736,7 @@ public class TestControlUnit extends AbstractWorker {
 				StraightLine camRay = new StraightLine(randomDetectorPoint, firstScatterPoint.getEndPoint());
 				camRay.normalize();
 
-				double theta = nHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), firstScatterPoint.getRayDir());
+				double theta = NHelperFkt.getAngleInRad(camRay.getDirection().multipliedBy(-1.0), firstScatterPoint.getRayDir());
 				double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(energyEV, theta);
 
 				double energy = XRayTracerSampling.getScatteredPhotonEnergy(energyEV, theta);
@@ -1817,7 +1817,7 @@ public class TestControlUnit extends AbstractWorker {
 
 						// This should be equal for all testcases
 						double distance = vertexHit.getEndPoint().euclideanDistance(resulting) * XRayTracer.milli;
-						double phi = nHelperFkt.getAngleInRad(newRay.getDirection().multipliedBy(-1.0),
+						double phi = NHelperFkt.getAngleInRad(newRay.getDirection().multipliedBy(-1.0),
 								normalOfDetector);
 						double dX = Math.cos(phi);
 						double gTerm = 1.0 / distance / distance;

--- a/src/edu/stanford/rsl/tutorial/physics/workingClass/VirtualPointWorker.java
+++ b/src/edu/stanford/rsl/tutorial/physics/workingClass/VirtualPointWorker.java
@@ -22,14 +22,14 @@ import edu.stanford.rsl.conrad.rendering.PriorityRayTracer;
 import edu.stanford.rsl.tutorial.physics.XRayHitVertex;
 import edu.stanford.rsl.tutorial.physics.XRayTracerSampling;
 import edu.stanford.rsl.tutorial.physics.XRayVPL;
-import edu.stanford.rsl.tutorial.physics.nHelperFkt;
+import edu.stanford.rsl.tutorial.physics.NHelperFkt;
 import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 /**
  * Implementation of the two step algorithm using virtual point lights for the calculation of indirect illumination
  * @author Tobias Miksch
  */
-public class virtualPointWorker extends AbstractWorker {
+public class VirtualPointWorker extends AbstractWorker {
 
 	
 	// For VPL
@@ -45,7 +45,7 @@ public class virtualPointWorker extends AbstractWorker {
 	private final CyclicBarrier barrierVPL;
 	private volatile XRayVPL collectionOfAllVPLs[];
 	
-	public virtualPointWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV,
+	public VirtualPointWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV,
 			Grid2D grid, XRayDetector detector, Projection proj, boolean infinite, boolean writeAdditionalData,
 			double sourceDetectorDist, double pixelDimensionX, double pixelDimensionY, Material background,
 			int versionNumber, int threadNumber, Random random, int lightRayLength,
@@ -262,7 +262,7 @@ public class virtualPointWorker extends AbstractWorker {
 				StraightLine camera = new StraightLine(randomDetectorPoint, vpLight.getVplPos());
 				camera.normalize();
 
-				double theta = nHelperFkt.getAngleInRad(camera.getDirection().multipliedBy(-1.0), vpLight.getDirection()); // .multipliedBy(-1.0)
+				double theta = NHelperFkt.getAngleInRad(camera.getDirection().multipliedBy(-1.0), vpLight.getDirection()); // .multipliedBy(-1.0)
 				double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(vpLight.getEnergyEV(), theta);
 
 				double energy = XRayTracerSampling.getScatteredPhotonEnergy(vpLight.getEnergyEV(), theta);

--- a/src/edu/stanford/rsl/tutorial/physics/workingClass/VirtualRayWorker.java
+++ b/src/edu/stanford/rsl/tutorial/physics/workingClass/VirtualRayWorker.java
@@ -30,14 +30,14 @@ import edu.stanford.rsl.tutorial.physics.XRayHitVertex;
 import edu.stanford.rsl.tutorial.physics.XRayTracerSampling;
 import edu.stanford.rsl.tutorial.physics.XRayVPL;
 import edu.stanford.rsl.tutorial.physics.XRayVRay;
-import edu.stanford.rsl.tutorial.physics.nHelperFkt;
+import edu.stanford.rsl.tutorial.physics.NHelperFkt;
 import edu.stanford.rsl.tutorial.physics.XRayTracer.RaytraceResult;
 
 /**
  * Implementation of the two step algorithm using virtual point lights for the calculation of indirect illumination
  * @author Tobias Miksch
  */
-public class virtualRayWorker extends AbstractWorker {
+public class VirtualRayWorker extends AbstractWorker {
 
 	// For VRL
 	private double vrlCreation = 0.3;
@@ -54,7 +54,7 @@ public class virtualRayWorker extends AbstractWorker {
 	private final CyclicBarrier barrierVRL;
 	private volatile XRayVRay allVirtualRayLights[];
 	
-	public virtualRayWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV,
+	public VirtualRayWorker(PriorityRayTracer raytracer, RaytraceResult res, long numRays, int startenergyEV,
 			Grid2D grid, XRayDetector detector, Projection proj, boolean infinite, boolean writeAdditionalData,
 			double sourceDetectorDist, double pixelDimensionX, double pixelDimensionY, Material background,
 			int versionNumber, int threadNumber, Random random, int lightRayLength,
@@ -278,7 +278,7 @@ public class virtualRayWorker extends AbstractWorker {
 			end = reversed ? e.getPoint() : e.getEnd();
 
 			// Search for the segment containing the rayPoint
-			if (foundStartSegment != -1 || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (foundStartSegment != -1 || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					rayPoint.getAbstractVector())) {
 				if (foundStartSegment == -1) {
 					foundStartSegment = i;
@@ -407,7 +407,7 @@ public class virtualRayWorker extends AbstractWorker {
 			end = reversed ? e.getPoint() : e.getEnd();
 
 			// Search for the segment containing the rayPoint
-			if (foundStartSegment != -1 || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
+			if (foundStartSegment != -1 || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(),
 					rayPoint.getAbstractVector())) {
 				if (foundStartSegment == -1) {
 					foundStartSegment = i;
@@ -522,7 +522,7 @@ public class virtualRayWorker extends AbstractWorker {
 			PointND start = reversed ? e.getEnd() : e.getPoint();
 			end = reversed ? e.getPoint() : e.getEnd();
 
-			if (foundStartSegment || nHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(), rayPoint.getAbstractVector())) {
+			if (foundStartSegment || NHelperFkt.isBetween(start.getAbstractVector(), end.getAbstractVector(), rayPoint.getAbstractVector())) {
 			
 				distToNextMaterial = rayPoint.euclideanDistance(end);
 				if (distToNextMaterial < 0.0) {
@@ -642,7 +642,7 @@ public class virtualRayWorker extends AbstractWorker {
 					StraightLine camera = new StraightLine(randomDetectorPoint, rayLightPoint);
 					camera.normalize();
 					
-					double theta = nHelperFkt.getAngleInRad(camera.getDirection().multipliedBy(-1.0), vRayLight.getDirection()); // .multipliedBy(-1.0)
+					double theta = NHelperFkt.getAngleInRad(camera.getDirection().multipliedBy(-1.0), vRayLight.getDirection()); // .multipliedBy(-1.0)
 					double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(vRayLight.getEnergyEV(), theta);
 
 					double energy = XRayTracerSampling.getScatteredPhotonEnergy(vRayLight.getEnergyEV(), theta);
@@ -757,12 +757,12 @@ public class virtualRayWorker extends AbstractWorker {
 
 					double throughputVRL = vRayLight.getTransmittance(fraction);
 					// Theta = Scatter angle
-					double theta = nHelperFkt.getAngleInRad(vRayLight.getDirection(), shadowRay.getDirection()); // .multipliedBy(-1.0)
+					double theta = NHelperFkt.getAngleInRad(vRayLight.getDirection(), shadowRay.getDirection()); // .multipliedBy(-1.0)
 					double lightPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(vRayLight.getEnergyEV(), theta);
 					double energy = XRayTracerSampling.getScatteredPhotonEnergy(vRayLight.getEnergyEV(), theta);
 					double throughputShadowRay = calculateTransmittance(rayLightPoint, cameraPoint, energy);
 
-					theta = nHelperFkt.getAngleInRad(shadowRay.getDirection(),
+					theta = NHelperFkt.getAngleInRad(shadowRay.getDirection(),
 							camPathVertex.getRayDir().multipliedBy(-1.0)); // .multipliedBy(-1.0)
 					double cameraPhaseFkt = XRayTracerSampling.comptonAngleCrossSection(vRayLight.getEnergyEV(), theta);
 					energy = XRayTracerSampling.getScatteredPhotonEnergy(energy, theta);


### PR DESCRIPTION
**Major**
Finally fixed a bug, where parsing the root package was not possible when executing CONRAD from runnable JAR file.

Parsing of the list of available reconstruction filters, numerical phantom classes (etc.) now differentiates between whether CONRAD was executed from JAR or as an unpacked project.

As of V 1.1.0 (hopefully) full functionality should be established in the released *.jar version for processes that require parsing of the source tree. If you encounter any problems with the jar version, please let us know.

---
**Minor**
Some formatting changes to comply with coding guidelines in the master thesis of Tobias Miksch.