### PR TITLE
Fixed two bugs in latest LightPCA commit.

### DIFF
--- a/src/edu/stanford/rsl/conrad/geometry/shapes/activeshapemodels/LightPCA.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/activeshapemodels/LightPCA.java
@@ -524,8 +524,8 @@ public class LightPCA {
 	 * @param numComp number of principal components
 	 */
 	public void reduceDimensionalityWithoutRetraining(int numComp) {
-		if(this.numComponents > numComp) {
-			throw new IllegalArgumentException("Can only ever decrease number of components, which is currently " + this.numComponents);
+		if(this.numComponents <= numComp) {
+			throw new IllegalArgumentException("Can only decrease the number of components, which is currently " + this.numComponents + " (numComp = " + numComp + " was given).");
 		}
 		
 		this.numComponents = numComp;

--- a/src/edu/stanford/rsl/conrad/geometry/shapes/activeshapemodels/LightPCA.java
+++ b/src/edu/stanford/rsl/conrad/geometry/shapes/activeshapemodels/LightPCA.java
@@ -530,6 +530,16 @@ public class LightPCA {
 		
 		this.numComponents = numComp;
 		this.reduceDimensionality(this.eigenValues, this.eigenVectors);
+		
+		// Cut off the appropriate rows from the training features.
+		this.features = this.features.getSubMatrix(0, 0, this.numComponents, this.features.getCols());
+		
+		if(DEBUG) {
+			System.out.println("Reduced Dimensionality without Retraining:");
+			System.out.println("#eigenvalues: " + this.eigenValues.length);
+			System.out.println("eigenVectors: " + this.eigenVectors.getRows() + " x " + this.eigenVectors.getCols());
+			System.out.println("features: " + this.features.getRows() + " x " + this.features.getCols());
+		}
 	}
 }
 


### PR DESCRIPTION
In `reduceDimensionalityWithoutRetraining(int numComp)`:
- Comparison of numComp was reversed
- PC scores of training data was not updated